### PR TITLE
fix: variable-length string attribute reading (Issue #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Stars](https://img.shields.io/github/stars/scigolib/hdf5?style=flat-square&logo=github)](https://github.com/scigolib/hdf5/stargazers)
 [![Discussions](https://img.shields.io/github/discussions/scigolib/hdf5?style=flat-square&logo=github&label=discussions)](https://github.com/scigolib/hdf5/discussions)
 
-A modern, pure Go library for reading and writing HDF5 files without CGo dependencies. **v0.13.0: HDF5 2.0.0 compatibility with security hardening, AI/ML datatypes, and 86.1% code coverage!**
+A modern, pure Go library for reading and writing HDF5 files without CGo dependencies. **v0.13.4: 100% HDF5 test suite pass rate, full attribute support including variable-length strings!**
 
 ---
 
@@ -393,8 +393,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ---
 
 **Status**: Stable - HDF5 2.0.0 compatible with security hardening
-**Version**: v0.13.0 (4 CVEs fixed, AI/ML datatypes, 86.1% coverage, 0 lint issues)
-**Last Updated**: 2025-11-13
+**Version**: v0.13.4 (100% HDF5 test suite pass rate, attribute reading fix, 86.1% coverage)
+**Last Updated**: 2025-01-29
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Advantage**: We have official HDF5 C library as reference implementation!
 > **Approach**: Port proven algorithms, not invent from scratch - Senior Go Developer mindset
 
-**Last Updated**: 2025-01-28 | **Current Version**: v0.13.3 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.3 RELEASED! (2025-01-28 compatibility improvements) → v1.0.0 LTS (Q3 2026)
+**Last Updated**: 2025-01-29 | **Current Version**: v0.13.4 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.4 RELEASED! (2025-01-29 attribute reading fix) → v1.0.0 LTS (Q3 2026)
 
 ---
 
@@ -93,6 +93,13 @@ v1.0.0 LTS → Long-term support release (Q3 2026)
 - Official HDF5 test suite: **100% pass rate** (378/378 valid files)
 - Added flux.h5 to test suite, professional error testing for corrupt files
 
+**v0.13.4** = Attribute Reading Fix ✅ RELEASED (2025-01-29)
+- Fixed Issue #14: Variable-length string attributes not readable
+- Fixed V1/V2 attribute message 8-byte alignment (H5O_ALIGN_OLD macro)
+- Fixed IsVariableString() detection (ClassBitField, not Properties)
+- Fixed vlen string data format (4-byte length prefix + Global Heap reference)
+- Files created by h5py now work correctly
+
 **v0.13.x** = Stable Maintenance Phase (current)
 - Monitoring for bug reports from production use
 - Performance optimizations when identified
@@ -112,7 +119,7 @@ v1.0.0 LTS → Long-term support release (Q3 2026)
 
 ---
 
-## 📊 Current Status (v0.13.3)
+## 📊 Current Status (v0.13.4)
 
 **Phase**: 🛡️ Stable Maintenance (monitoring, community support)
 **HDF5 2.0.0 Format Spec v4.0**: Complete! 🎉
@@ -397,5 +404,5 @@ v1.0.0 LTS → Long-term support release (Q3 2026)
 ---
 
 *Version 5.2 (Updated 2025-01-27)*
-*Current: v0.13.3 (STABLE) | Phase: Maintenance | Next: v0.14.0+ (community-driven) | Target: v1.0.0 LTS (Q3 2026)*
+*Current: v0.13.4 (STABLE) | Phase: Maintenance | Next: v0.14.0+ (community-driven) | Target: v1.0.0 LTS (Q3 2026)*
 

--- a/docs/guides/DATATYPES.md
+++ b/docs/guides/DATATYPES.md
@@ -421,7 +421,12 @@ if err == nil {
 
 ```go
 for _, attr := range attrs {
-    switch v := attr.Value.(type) {
+    value, err := attr.ReadValue()
+    if err != nil {
+        fmt.Printf("error reading %s: %v\n", attr.Name, err)
+        continue
+    }
+    switch v := value.(type) {
     case int32:
         fmt.Printf("int32: %d\n", v)
     case int64:

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -163,7 +163,7 @@ See [ROADMAP.md](../../ROADMAP.md) for future plans.
 
 ### Can I read attributes?
 
-**Yes!** Full attribute reading support:
+**Yes!** Full attribute reading support including variable-length strings:
 
 ```go
 // Group attributes
@@ -174,13 +174,19 @@ attrs, err := dataset.Attributes()
 
 // Access attribute values
 for _, attr := range attrs {
-    fmt.Printf("%s = %v (type: %T)\n", attr.Name, attr.Value, attr.Value)
+    value, err := attr.ReadValue()
+    if err != nil {
+        log.Printf("Error reading %s: %v", attr.Name, err)
+        continue
+    }
+    fmt.Printf("%s = %v (type: %T)\n", attr.Name, value, value)
 }
 ```
 
 **Supported**:
 - ✅ Compact attributes (in object header)
 - ✅ Dense attributes (fractal heap direct blocks)
+- ✅ All datatypes including variable-length strings (v0.13.4+)
 
 **Note**: Dense attributes (8+ attributes) fully supported via B-tree v2 and fractal heap.
 

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -179,15 +179,21 @@ for i, child := range root.Children() {
 
 **Error Message**:
 ```
-Error: unsupported datatype: H5T_ARRAY
 Error: unsupported datatype class: 10
+Error: unsupported datatype class 9 or size 16
 ```
 
-**Cause**: Dataset uses a datatype not yet implemented.
+**Cause**: Dataset or attribute uses a datatype not yet implemented.
 
-**Supported Types**: int32, int64, float32, float64, strings, compounds
+**Supported Types (v0.13.4+)**:
+- Integer types (int8-64, uint8-64)
+- Floating point (float32, float64, bfloat16, FP8)
+- Strings (fixed-length and variable-length)
+- Compounds (nested structures)
+- Arrays, Enums, References, Opaque
 
-**Unsupported**: arrays, enums, references, opaque, time
+**Note**: If you see "unsupported datatype class 9", upgrade to v0.13.4+ which adds
+variable-length string support for attributes.
 
 **Solution**:
 
@@ -375,21 +381,28 @@ panic: interface conversion: interface {} is float64, not int32
 
 **Solution**:
 
-Always use safe type assertion:
+Always read the value first, then use safe type assertion:
 
 ```go
+// Read the attribute value
+value, err := attr.ReadValue()
+if err != nil {
+    log.Printf("Error reading attribute: %v", err)
+    return
+}
+
 // Bad: Direct assertion (can panic)
-value := attr.Value.(int32)
+intValue := value.(int32)
 
 // Good: Safe assertion with check
-if value, ok := attr.Value.(int32); ok {
-    fmt.Printf("int32: %d\n", value)
+if intValue, ok := value.(int32); ok {
+    fmt.Printf("int32: %d\n", intValue)
 } else {
-    fmt.Printf("Not int32, actual type: %T\n", attr.Value)
+    fmt.Printf("Not int32, actual type: %T\n", value)
 }
 
 // Best: Use type switch
-switch v := attr.Value.(type) {
+switch v := value.(type) {
 case int32:
     fmt.Printf("int32: %d\n", v)
 case int64:

--- a/internal/core/datatype.go
+++ b/internal/core/datatype.go
@@ -199,15 +199,15 @@ func (dt *DatatypeMessage) IsFixedString() bool {
 }
 
 // IsVariableString checks if datatype is a variable-length string.
+// Reference: HDF5 Format Specification III.A.2.4.d (Variable-Length Types).
 func (dt *DatatypeMessage) IsVariableString() bool {
 	if dt.Class == DatatypeVarLen {
-		// Variable-length datatype.
-		// Properties start with base type class (4 bits in first byte).
-		if len(dt.Properties) > 0 {
-			baseClass := DatatypeClass(dt.Properties[0] & 0x0F)
-			return baseClass == DatatypeString
-		}
-		return true // Assume string if no properties.
+		// For variable-length types, ClassBitField contains:
+		// - Bits 0-3: Type (0=Sequence, 1=String)
+		// - Bits 4-7: Padding type (for strings)
+		// - Bits 8-11: Character set (for strings, 0=ASCII, 1=UTF-8)
+		vlType := dt.ClassBitField & 0x0F
+		return vlType == 1 // 1 = variable-length string
 	}
 	return false
 }

--- a/internal/core/datatype_helpers_test.go
+++ b/internal/core/datatype_helpers_test.go
@@ -262,6 +262,8 @@ func TestIsFixedString(t *testing.T) {
 }
 
 // TestIsVariableString tests variable-length string detection.
+// Reference: HDF5 Format Specification III.A.2.4.d (Variable-Length Types).
+// ClassBitField bits 0-3 contain the VL type: 0=Sequence, 1=String.
 func TestIsVariableString(t *testing.T) {
 	tests := []struct {
 		name string
@@ -269,26 +271,26 @@ func TestIsVariableString(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "varlen string with properties",
+			name: "varlen string (type=1)",
 			dt: &DatatypeMessage{
-				Class:      DatatypeVarLen,
-				Properties: []byte{0x03}, // Base class = DatatypeString (3)
+				Class:         DatatypeVarLen,
+				ClassBitField: 0x0001, // Type = 1 (String)
 			},
 			want: true,
 		},
 		{
-			name: "varlen without properties",
+			name: "varlen string UTF-8 (type=1, charset=1)",
 			dt: &DatatypeMessage{
-				Class:      DatatypeVarLen,
-				Properties: []byte{},
+				Class:         DatatypeVarLen,
+				ClassBitField: 0x0101, // Type = 1 (String), Charset = 1 (UTF-8)
 			},
 			want: true,
 		},
 		{
-			name: "varlen non-string base",
+			name: "varlen sequence (type=0)",
 			dt: &DatatypeMessage{
-				Class:      DatatypeVarLen,
-				Properties: []byte{0x01}, // Base class = DatatypeFloat (1)
+				Class:         DatatypeVarLen,
+				ClassBitField: 0x0000, // Type = 0 (Sequence)
 			},
 			want: false,
 		},


### PR DESCRIPTION
## Summary

Fixes #14 - Users couldn't read attributes from HDF5 files created by h5py.

**Root causes identified and fixed:**

1. **V1/V2 Attribute Alignment**: Name, datatype, and dataspace fields must be padded to 8-byte boundaries (per `H5O_ALIGN_OLD` macro in C library)

2. **IsVariableString() Detection**: Was checking `Properties[0] & 0x0F == DatatypeString`, but per HDF5 Format Spec III.A.2.4.d, variable-length string type is indicated by `ClassBitField & 0x0F == 1`

3. **VLen String Data Format**: Variable-length strings include a 4-byte length prefix before the Global Heap reference, making the total size `4 + offsetSize + 4` bytes

**Changes:**
- `internal/core/attribute.go` - Added `DatatypeVarLen` case to `ReadValue()`, fixed 8-byte alignment
- `internal/core/datatype.go` - Fixed `IsVariableString()` to check `ClassBitField` correctly
- `internal/core/attribute_test.go` - Added unit tests for vlen string attributes
- Documentation updated with correct `attr.ReadValue()` API

## Test Results

```
Group '/' has 1 attributes:
  - File Attribute = 123456

Dataset: Test Dataset
Dataset 'Test Dataset' has 2 attributes:
  - Dataset Attribute 1 = Test Attribute 1
  - Dataset Attribute 2 = Test Attribute 2
```

- All tests pass ✅
- Linter: 0 issues ✅
- Official HDF5 Suite: 100% (378/378) ✅

## Test plan

- [x] Unit tests for `IsVariableString()` detection
- [x] Unit tests for vlen attribute `ReadValue()` error cases
- [x] Integration test with h5py-created file
- [x] Official HDF5 test suite (100% pass rate maintained)
- [x] Linter passes (0 issues)