### PR TITLE
fix: update superblock EOA on file close (Issue #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v0.13.8] - 2026-03-04
+
+### 🐛 Bug Fix
+
+#### Superblock EOA Compatibility (Issue #22)
+
+Fixed a critical compatibility issue where HDF5 files created by this library could not be
+read by h5py, h5wasm, or other HDF5 readers. The root cause was that the superblock's
+End-of-File Address (EOA) was written once at file creation time but never updated as
+datasets, attributes, and groups were added to the file.
+
+**Symptoms**: h5py reported `KeyError: 'Unable to synchronously open object (actual len exceeds EOA)'`,
+h5wasm reported `actual_len exceeds EOA`.
+
+**Fix**: `FileWriter.Close()` now rewrites the superblock with the final EOA from the allocator
+before closing the file. This ensures the EOA always matches the actual file size.
+
+**Impact**: All files created with v0.11.0 through v0.13.7 may have incorrect EOA if they
+contain any datasets or attributes. Files created with v0.13.8+ are fully compatible with
+h5py, h5wasm, h5dump, and the HDF5 C library.
+
+Reported by [@vrv-bit](https://github.com/vrv-bit).
+
+#### FileWriter.Close() resource leak on Windows
+
+`FileWriter.Close()` now also closes the read-side file handle opened by `OpenForWrite()`.
+Previously, the `*File` handle from `Open()` was never closed, causing Windows file locking
+errors during cleanup (e.g., `t.TempDir()` removal in tests).
+
+---
+
 ## [v0.13.7] - 2026-02-27
 
 ### 🧪 Test Coverage Boost

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Advantage**: We have official HDF5 C library as reference implementation!
 > **Approach**: Port proven algorithms, not invent from scratch - Senior Go Developer mindset
 
-**Last Updated**: 2026-02-24 | **Current Version**: v0.13.6 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.6 RELEASED! (2026-02-24) → v1.0.0 LTS (Q3 2026)
+**Last Updated**: 2026-03-04 | **Current Version**: v0.13.8 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.8 RELEASED! (2026-03-04) → v1.0.0 LTS (Q3 2026)
 
 ---
 
@@ -53,6 +53,8 @@ v0.13.2 (BUGFIX - V0 superblock) ✅ RELEASED 2025-01-17
          ↓ (compatibility improvements)
 v0.13.3 (FEATURE - Named Datatypes, Soft Links) ✅ RELEASED 2025-01-28
          ↓ (community adoption + feedback + monitoring)
+v0.13.8 (HOTFIX - EOA compatibility) ✅ RELEASED 2026-03-04
+         ↓ (maintenance continues)
 v0.13.x (maintenance phase) → Stable maintenance, bug fixes, minor enhancements
          ↓ (6-9 months production validation)
 v1.0.0 LTS → Long-term support release (Q3 2026)

--- a/dataset_write.go
+++ b/dataset_write.go
@@ -2276,6 +2276,18 @@ func (fw *FileWriter) Close() error {
 		}
 	}
 
+	// CRITICAL FIX (Issue #22): Rewrite superblock with final End-of-File address.
+	// The superblock EOA is written once at file creation time, but subsequent
+	// allocations (datasets, attributes, groups) extend the file beyond the
+	// initial EOA. Without updating it, h5py/h5wasm/h5dump fail with
+	// "actual len exceeds EOA".
+	if fw.file != nil && fw.file.sb != nil {
+		finalEOF := fw.writer.EndOfFile()
+		if err := fw.file.sb.WriteTo(fw.writer, finalEOF); err != nil {
+			return fmt.Errorf("failed to update superblock EOA: %w", err)
+		}
+	}
+
 	// Flush buffered writes
 	if err := fw.writer.Flush(); err != nil {
 		return fmt.Errorf("failed to flush: %w", err)
@@ -2284,6 +2296,15 @@ func (fw *FileWriter) Close() error {
 	// Close writer
 	if err := fw.writer.Close(); err != nil {
 		return fmt.Errorf("failed to close writer: %w", err)
+	}
+
+	// Close the read-side file handle (opened by OpenForWrite via Open()).
+	// On Windows, an unclosed handle prevents TempDir cleanup and any
+	// subsequent file operations.
+	if fw.file != nil {
+		if err := fw.file.Close(); err != nil {
+			return fmt.Errorf("failed to close read handle: %w", err)
+		}
 	}
 
 	fw.writer = nil


### PR DESCRIPTION
## Summary

- Fix superblock End-of-File Address (EOA) not being updated on `FileWriter.Close()`
- EOA was written once at file creation, but never updated as datasets/attributes/groups were added
- h5py, h5wasm, and h5dump could not read files created by this library

**Root cause**: `FileWriter.Close()` did not rewrite the superblock with the final EOA from the allocator.

**Fix**: Added superblock rewrite with `fw.writer.EndOfFile()` before flushing and closing.

Fixes #22

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Lint: 0 issues (`golangci-lint run ./...`)
- [x] EOA verification: superblock EOA matches actual file size after writing datasets
- [x] Round-trip test: write multiple datasets → close → reopen → read all data correctly
- [x] Race detector: clean (WSL2 Gentoo, `go test -race ./...`)
