### PR TITLE
feat: add VLenUint8 datatype (Issue #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v0.13.12] - 2026-03-14
+
+### Enhancement
+
+#### Add VLenUint8 datatype (Issue #30)
+
+Added `VLenUint8` (Go type: `[][]byte`) for storing variable-length byte arrays. This completes
+the VLen type family — all other numeric VLen types (Int32, Int64, Float32, Float64, Uint32,
+Uint64) were already supported. Useful for serialized binary data (protobuf, ROS messages),
+compatible with C++ `H5::VarLenType(H5::PredType::STD_U8LE)`.
+
+Requested by [@zhoujun24](https://github.com/zhoujun24).
+
+---
+
 ## [v0.13.11] - 2026-03-14
 
 ### Bug Fix

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Advantage**: We have official HDF5 C library as reference implementation!
 > **Approach**: Port proven algorithms, not invent from scratch - Senior Go Developer mindset
 
-**Last Updated**: 2026-03-14 | **Current Version**: v0.13.11 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.11 RELEASED! (2026-03-14) → v1.0.0 LTS (Q3 2026)
+**Last Updated**: 2026-03-14 | **Current Version**: v0.13.12 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.12 RELEASED! (2026-03-14) → v1.0.0 LTS (Q3 2026)
 
 ---
 
@@ -60,6 +60,8 @@ v0.13.9 (HOTFIX - V2 object header checksum) ✅ RELEASED 2026-03-04
 v0.13.10 (BUGFIX - h5dump/h5ls/h5py interop) ✅ RELEASED 2026-03-06
          ↓ (attribute + SNOD + B-tree key fixes)
 v0.13.11 (HOTFIX - write interop: attrs, sorting, keys) ✅ RELEASED 2026-03-14
+         ↓ (add missing VLenUint8 type)
+v0.13.12 (PATCH - add VLenUint8 datatype) ✅ RELEASED 2026-03-14
          ↓ (maintenance continues)
 v0.13.x (maintenance phase) → Stable maintenance, bug fixes, minor enhancements
          ↓ (6-9 months production validation)

--- a/dataset_write.go
+++ b/dataset_write.go
@@ -136,6 +136,10 @@ const (
 	// VLenUint64 represents variable-length uint64 sequences.
 	// Go type: [][]uint64.
 	VLenUint64 Datatype = 506
+
+	// VLenUint8 represents variable-length uint8 sequences (byte arrays).
+	// Go type: [][]byte.
+	VLenUint8 Datatype = 507
 )
 
 // Unlimited represents unlimited dimension size for resizable datasets.
@@ -523,6 +527,7 @@ func init() {
 		VLenFloat64: &vlenTypeHandler{Float64},
 		VLenUint32:  &vlenTypeHandler{Uint32},
 		VLenUint64:  &vlenTypeHandler{Uint64},
+		VLenUint8:   &vlenTypeHandler{Uint8},
 	}
 }
 
@@ -1311,7 +1316,7 @@ func (dw *DatasetWriter) WriteRaw(data []byte) error {
 // writeVLen handles writing variable-length data (strings, ragged arrays).
 // Data is written to global heap, and heap IDs are stored in the dataset.
 //
-//nolint:gocyclo,gocognit,cyclop,funlen // Complex by nature: handles multiple vlen types with validation
+//nolint:gocyclo,gocognit,cyclop,funlen,maintidx // Complex by nature: handles multiple vlen types with validation
 func (dw *DatasetWriter) writeVLen(data interface{}) error {
 	// Calculate expected number of elements
 	elemCount := uint64(1)
@@ -1451,6 +1456,21 @@ func (dw *DatasetWriter) writeVLen(data interface{}) error {
 			heapID, err := dw.fileWriter.globalHeapWriter.WriteToGlobalHeap(seqBytes)
 			if err != nil {
 				return fmt.Errorf("write float64 sequence %d to heap: %w", i, err)
+			}
+			heapIDs[i] = heapID
+		}
+
+	case [][]byte:
+		// Variable-length uint8 sequences (byte arrays)
+		if uint64(len(v)) != elemCount {
+			return fmt.Errorf("data length %d doesn't match dataset size %d", len(v), elemCount)
+		}
+
+		for i, seq := range v {
+			// Uint8 elements are single bytes — direct copy, no binary encoding needed.
+			heapID, err := dw.fileWriter.globalHeapWriter.WriteToGlobalHeap(seq)
+			if err != nil {
+				return fmt.Errorf("write uint8 sequence %d to heap: %w", i, err)
 			}
 			heapIDs[i] = heapID
 		}

--- a/vlen_write_test.go
+++ b/vlen_write_test.go
@@ -1,7 +1,9 @@
 package hdf5
 
 import (
+	"bytes"
 	"encoding/binary"
+	"fmt"
 	"os"
 	"testing"
 
@@ -321,6 +323,121 @@ func TestVLenUint32(t *testing.T) {
 	ragged := [][]uint32{{1, 2, 3}, {4}}
 	if err := ds.Write(ragged); err != nil {
 		t.Fatalf("Write failed: %v", err)
+	}
+}
+
+// TestVLenUint8 tests uint8 variable-length byte arrays.
+func TestVLenUint8(t *testing.T) {
+	filename := "test_vlen_uint8.h5"
+	fw, err := CreateForWrite(filename, CreateTruncate)
+	if err != nil {
+		t.Fatalf("CreateForWrite failed: %v", err)
+	}
+	defer os.Remove(filename)
+	defer fw.Close()
+
+	ds, err := fw.CreateDataset("/bytes", VLenUint8, []uint64{3})
+	if err != nil {
+		t.Fatalf("CreateDataset failed: %v", err)
+	}
+
+	ragged := [][]byte{{0x01, 0x02, 0x03}, {0xFF}, {0x00, 0xAB}}
+	if err := ds.Write(ragged); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// Close and reopen to verify structure.
+	if err := fw.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	f, err := Open(filename)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	// Verify dataset exists.
+	found := false
+	for _, child := range f.Root().Children() {
+		if child.Name() == "bytes" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("Dataset 'bytes' not found after reopen")
+	}
+
+	// Read heap IDs from file and verify stored data via subtests.
+	dataAddr := ds.dataAddress
+	heapIDData := make([]byte, 3*16) // 3 elements x 16 bytes each
+	if _, err := f.Reader().ReadAt(heapIDData, int64(dataAddr)); err != nil {
+		t.Fatalf("ReadAt failed: %v", err)
+	}
+
+	for i, expected := range ragged {
+		t.Run(fmt.Sprintf("element_%d", i), func(t *testing.T) {
+			heapAddr := binary.LittleEndian.Uint64(heapIDData[i*16 : i*16+8])
+			heapIdx := binary.LittleEndian.Uint32(heapIDData[i*16+8 : i*16+12])
+
+			ghc, err := core.ReadGlobalHeapCollection(f.Reader(), heapAddr, 8)
+			if err != nil {
+				t.Fatalf("ReadGlobalHeapCollection failed: %v", err)
+			}
+
+			obj, err := ghc.GetObject(heapIdx)
+			if err != nil {
+				t.Fatalf("GetObject(%d) failed: %v", heapIdx, err)
+			}
+
+			if !bytes.Equal(obj.Data, expected) {
+				t.Errorf("data mismatch: got %v, want %v", obj.Data, expected)
+			}
+		})
+	}
+}
+
+// TestVLenUint8Empty tests empty byte sequences.
+func TestVLenUint8Empty(t *testing.T) {
+	filename := "test_vlen_uint8_empty.h5"
+	fw, err := CreateForWrite(filename, CreateTruncate)
+	if err != nil {
+		t.Fatalf("CreateForWrite failed: %v", err)
+	}
+	defer os.Remove(filename)
+	defer fw.Close()
+
+	ds, err := fw.CreateDataset("/empty_bytes", VLenUint8, []uint64{3})
+	if err != nil {
+		t.Fatalf("CreateDataset failed: %v", err)
+	}
+
+	ragged := [][]byte{{}, {0x42}, {}}
+	if err := ds.Write(ragged); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+}
+
+// TestVLenUint8SizeMismatch tests error when data size doesn't match dimensions.
+func TestVLenUint8SizeMismatch(t *testing.T) {
+	filename := "test_vlen_uint8_mismatch.h5"
+	fw, err := CreateForWrite(filename, CreateTruncate)
+	if err != nil {
+		t.Fatalf("CreateForWrite failed: %v", err)
+	}
+	defer os.Remove(filename)
+	defer fw.Close()
+
+	ds, err := fw.CreateDataset("/bytes", VLenUint8, []uint64{3})
+	if err != nil {
+		t.Fatalf("CreateDataset failed: %v", err)
+	}
+
+	// Wrong number of elements.
+	err = ds.Write([][]byte{{0x01}, {0x02}})
+	if err == nil {
+		t.Error("Expected error for size mismatch, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `VLenUint8` (`Datatype = 507`, Go type `[][]byte`) for variable-length byte arrays
- Completes the VLen type family — all other numeric variants already existed
- Useful for serialized binary data (protobuf, ROS messages), compatible with C++ `H5::VarLenType(H5::PredType::STD_U8LE)`

## Test plan

- [x] `TestVLenUint8` — write 3 ragged byte arrays, reopen, verify via global heap readback
- [x] `TestVLenUint8Empty` — mix of empty and non-empty sequences
- [x] `TestVLenUint8SizeMismatch` — error on wrong element count
- [x] Full test suite passes, lint clean (0 issues)

Closes #30
