### PR TITLE
fix: B-tree key semantics for SNOD split (Issue #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v0.13.14] - 2026-03-19
+
+### Bug Fix
+
+#### B-tree key semantics for SNOD split (Issue #35 follow-up)
+
+Fixed 2 bugs in the B-tree key layout introduced by the v0.13.13 SNOD splitting implementation.
+Files created by v0.13.13 with any number of datasets were unreadable by h5dump, h5ls, and h5wasm.
+
+**Bug #1: Key[0] was first entry's name offset instead of 0**
+
+Per C reference (`H5G__node_create`, H5Gnode.c:306-309), the left key of the first child must
+always be 0 (the empty string sentinel at heap offset 0). The rewritten `linkToParent()` set it
+to the first entry's name offset, causing `H5G__node_cmp3` to return "before this child" for
+all names, making the entire group invisible.
+
+**Bug #2: Middle key was first entry of right SNOD instead of last entry of left SNOD**
+
+Per C reference (`H5G__node_insert`, H5Gnode.c:623), `md_key->offset = sn->entry[sn->nsyms-1].name_off`
+— the boundary key between two children is the last entry of the LEFT node. Our code used the
+first entry of the right node, causing `H5G__node_cmp3` to fail for names exactly matching the
+boundary (strncmp returns 0, which is <= 0, interpreted as "before this child").
+
+**Validation**: h5dump correctly reads files with 1, 2, 3, 8, 9, 10, and 20 datasets, both at
+root level and inside groups.
+
+Reported by [@vrv-bit](https://github.com/vrv-bit).
+
+---
+
 ## [v0.13.13] - 2026-03-18
 
 ### Bug Fix

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Advantage**: We have official HDF5 C library as reference implementation!
 > **Approach**: Port proven algorithms, not invent from scratch - Senior Go Developer mindset
 
-**Last Updated**: 2026-03-18 | **Current Version**: v0.13.13 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.13 RELEASED! (2026-03-18) → v1.0.0 LTS (Q3 2026)
+**Last Updated**: 2026-03-19 | **Current Version**: v0.13.14 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.14 RELEASED! (2026-03-19) → v1.0.0 LTS (Q3 2026)
 
 ---
 
@@ -64,6 +64,8 @@ v0.13.11 (HOTFIX - write interop: attrs, sorting, keys) ✅ RELEASED 2026-03-14
 v0.13.12 (PATCH - add VLenUint8 datatype) ✅ RELEASED 2026-03-14
          ↓ (SNOD split, heap expansion, chunk format fix)
 v0.13.13 (BUGFIX - SNOD/heap/chunk interop) ✅ RELEASED 2026-03-18
+         ↓ (B-tree key fix for SNOD split)
+v0.13.14 (HOTFIX - B-tree key semantics) ✅ RELEASED 2026-03-19
          ↓ (maintenance continues)
 v0.13.x (maintenance phase) → Stable maintenance, bug fixes, minor enhancements
          ↓ (6-9 months production validation)

--- a/group_write.go
+++ b/group_write.go
@@ -382,11 +382,21 @@ func (fw *FileWriter) linkToParent(parentPath, childName string, childAddr uint6
 	newBTree := structures.NewBTreeNodeV1(0, groupBTreeK)
 
 	for i := 0; i < numSNODs; i++ {
-		// Left key for this child = offset of first entry in this SNOD (or 0 for first).
-		startIdx := i * snodCapacity
+		// Per C reference H5G__node_create (H5Gnode.c:306-309): initial keys are 0.
+		// Per H5G__node_cmp3 (H5Gnode.c:415): search_name <= left_key returns -1 (before).
+		// Per H5G__node_insert (H5Gnode.c:623): md_key = last entry of LEFT node.
+		//
+		// Key[0] = 0 (empty string sentinel)
+		// Key[i] for i>0 = last entry's name offset in SNOD[i-1] (the boundary between nodes)
+		// This ensures cmp3 returns 0 for names that belong in the RIGHT node.
 		var leftKey uint64
-		if startIdx < len(allEntries) {
-			leftKey = allEntries[startIdx].LinkNameOffset
+		if i > 0 {
+			// Boundary key = last entry of the previous SNOD
+			prevEnd := i * snodCapacity
+			if prevEnd > len(allEntries) {
+				prevEnd = len(allEntries)
+			}
+			leftKey = allEntries[prevEnd-1].LinkNameOffset
 		}
 		if addErr := newBTree.AddKey(leftKey, snodAddrs[i]); addErr != nil {
 			return fmt.Errorf("add B-tree key for SNOD %d: %w", i, addErr)


### PR DESCRIPTION
## Summary

Fixes 2 bugs in B-tree key layout introduced by v0.13.13 SNOD splitting (Issue #35 follow-up).

- **Key[0]** was set to first entry's name offset instead of 0 (empty string sentinel). Per `H5G__node_create` (H5Gnode.c:306-309).
- **Middle key** was first entry of right SNOD instead of last entry of left SNOD. Per `H5G__node_insert` (H5Gnode.c:623).

Both caused `H5G__node_cmp3` to fail name lookups, making all files created by v0.13.13 unreadable by h5dump/h5ls/h5wasm.

## Test plan

- [x] h5dump verifies files with 1, 2, 3, 8, 9, 10 datasets (root + group)
- [x] All existing tests pass (`go test -short ./...`)
- [x] Lint clean (0 issues)
