### PR TITLE
fix: VLen datatype encoding + ReadVLenBytes (Issue #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v0.13.15] - 2026-03-30
+
+### Bug Fix
+
+#### VLen datatype encoding + read support (Issue #39)
+
+**Bug #1: `encodeDatatypeVlen` class/version nibbles swapped**
+
+Per C reference (`H5Odtype.c:1439`), byte 0 of datatype messages encodes
+`class (bits 0-3) | version (bits 4-7)`. Our VLen encoder wrote `version | (class << 4)`,
+producing `0x90` for VLen class=9 instead of the correct `0x09`. On readback, `0x90 & 0x0F = 0`
+was misidentified as Fixed-point integer. Additionally, ClassBitField was written at bytes 8-11
+instead of bytes 1-3. All other encode functions (numeric, string, compound, etc.) were correct.
+
+**Bug #2: No VLen read support**
+
+`Read()`, `ReadHyperslab()`, and `ReadSlice()` only supported numeric-to-float64 conversion.
+Added `ReadVLenBytes()` method on `Dataset` that dereferences global heap IDs and returns
+`[][]byte`. Supports compact, contiguous, and chunked layouts.
+
+Reported by [@zhoujun24](https://github.com/zhoujun24).
+
+---
+
 ## [v0.13.14] - 2026-03-19
 
 ### Bug Fix

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Advantage**: We have official HDF5 C library as reference implementation!
 > **Approach**: Port proven algorithms, not invent from scratch - Senior Go Developer mindset
 
-**Last Updated**: 2026-03-19 | **Current Version**: v0.13.14 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.14 RELEASED! (2026-03-19) → v1.0.0 LTS (Q3 2026)
+**Last Updated**: 2026-03-30 | **Current Version**: v0.13.15 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.15 RELEASED! (2026-03-30) → v1.0.0 LTS (Q3 2026)
 
 ---
 
@@ -66,6 +66,8 @@ v0.13.12 (PATCH - add VLenUint8 datatype) ✅ RELEASED 2026-03-14
 v0.13.13 (BUGFIX - SNOD/heap/chunk interop) ✅ RELEASED 2026-03-18
          ↓ (B-tree key fix for SNOD split)
 v0.13.14 (HOTFIX - B-tree key semantics) ✅ RELEASED 2026-03-19
+         ↓ (VLen encode fix + read support)
+v0.13.15 (BUGFIX - VLen encoding + ReadVLenBytes) ✅ RELEASED 2026-03-30
          ↓ (maintenance continues)
 v0.13.x (maintenance phase) → Stable maintenance, bug fixes, minor enhancements
          ↓ (6-9 months production validation)

--- a/group.go
+++ b/group.go
@@ -138,6 +138,24 @@ func (d *Dataset) ReadCompound() ([]core.CompoundValue, error) {
 	return core.ReadDatasetCompound(d.file.osFile, header, d.file.sb)
 }
 
+// ReadVLenBytes reads a variable-length dataset and returns values as [][]byte.
+// Each element in the outer slice corresponds to one dataset element; each inner
+// slice contains the raw bytes of that variable-length sequence.
+//
+// This works for any VLen datatype (VLenUint8, VLenInt32, VLenString, etc.).
+// For typed sequences the caller must interpret the returned bytes according
+// to the base element type and byte order.
+func (d *Dataset) ReadVLenBytes() ([][]byte, error) {
+	// Read object header for this dataset.
+	header, err := core.ReadObjectHeader(d.file.osFile, d.address, d.file.sb)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the variable-length dataset reader.
+	return core.ReadDatasetVLenBytes(d.file.osFile, header, d.file.sb)
+}
+
 // Info returns metadata about the dataset without reading actual values.
 func (d *Dataset) Info() (string, error) {
 	header, err := core.ReadObjectHeader(d.file.osFile, d.address, d.file.sb)

--- a/integration_dense_rmw_test.go
+++ b/integration_dense_rmw_test.go
@@ -367,7 +367,6 @@ func createShortPathTempFile(t *testing.T, name string) string {
 	return tmpFile
 }
 
-//nolint:unparam // targetPath parameter designed for reusability in future tests
 func findDataset(f *File, targetPath string) *Dataset {
 	var found *Dataset
 	f.Walk(func(p string, obj Object) {

--- a/internal/core/dataset_reader_vlen.go
+++ b/internal/core/dataset_reader_vlen.go
@@ -1,0 +1,163 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ReadDatasetVLenBytes reads a variable-length dataset and returns values as [][]byte.
+// Each element in the outer slice corresponds to one dataset element; each inner slice
+// contains the raw bytes of that variable-length sequence.
+//
+// This works for any VLen datatype (sequences and strings). For VLen strings the
+// returned bytes are the raw UTF-8/ASCII characters without a null terminator.
+//
+// C Reference: H5Tvlen.c, H5HG.c (global heap object retrieval).
+func ReadDatasetVLenBytes(r io.ReaderAt, header *ObjectHeader, sb *Superblock) ([][]byte, error) {
+	// 1. Extract required messages from object header.
+	var datatypeMsg, dataspaceMsg, layoutMsg *HeaderMessage
+
+	for _, msg := range header.Messages {
+		switch msg.Type {
+		case MsgDatatype:
+			datatypeMsg = msg
+		case MsgDataspace:
+			dataspaceMsg = msg
+		case MsgDataLayout:
+			layoutMsg = msg
+		}
+	}
+
+	// Validate we have all required messages.
+	if datatypeMsg == nil {
+		return nil, errors.New("datatype message not found")
+	}
+	if dataspaceMsg == nil {
+		return nil, errors.New("dataspace message not found")
+	}
+	if layoutMsg == nil {
+		return nil, errors.New("data layout message not found")
+	}
+
+	// 2. Parse datatype.
+	datatype, err := ParseDatatypeMessage(datatypeMsg.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse datatype: %w", err)
+	}
+
+	// Verify it's a variable-length type.
+	if datatype.Class != DatatypeVarLen {
+		return nil, fmt.Errorf("datatype is not variable-length: class=%d", datatype.Class)
+	}
+
+	// 3. Parse dataspace.
+	dataspace, err := ParseDataspaceMessage(dataspaceMsg.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse dataspace: %w", err)
+	}
+
+	// 4. Parse layout.
+	layout, err := ParseDataLayoutMessage(layoutMsg.Data, sb)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse layout: %w", err)
+	}
+
+	// 5. Calculate total number of elements.
+	totalElements := dataspace.TotalElements()
+	if totalElements == 0 {
+		return [][]byte{}, nil
+	}
+
+	// 6. Read raw data (heap IDs) based on layout type.
+	// Each VLen element is stored as a global heap reference:
+	//   heap_address (OffsetSize bytes) + object_index (4 bytes) + padding to 16 bytes.
+	// datatype.Size is 16 (heap ID size).
+	var rawData []byte
+
+	switch {
+	case layout.IsCompact():
+		rawData = layout.CompactData
+
+	case layout.IsContiguous():
+		dataSize := totalElements * uint64(datatype.Size)
+		rawData = make([]byte, dataSize)
+
+		//nolint:gosec // G115: HDF5 addresses fit in int64 for io.ReaderAt interface
+		_, err := r.ReadAt(rawData, int64(layout.DataAddress))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read contiguous data: %w", err)
+		}
+
+	case layout.IsChunked():
+		// Extract filter pipeline if present.
+		var filterPipeline *FilterPipelineMessage
+		for _, msg := range header.Messages {
+			if msg.Type == MsgFilterPipeline {
+				filterPipeline, err = ParseFilterPipelineMessage(msg.Data)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse filter pipeline: %w", err)
+				}
+				break
+			}
+		}
+
+		rawData, err = readChunkedData(r, layout, dataspace, datatype, sb, filterPipeline)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read chunked data: %w", err)
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported layout class: %d", layout.Class)
+	}
+
+	// 7. Dereference global heap IDs to retrieve actual data.
+	offsetSize := int(sb.OffsetSize)
+	heapIDSize := uint64(datatype.Size) // Typically 16 bytes.
+	result := make([][]byte, totalElements)
+
+	// Cache global heap collections to avoid re-reading the same collection.
+	heapCache := make(map[uint64]*GlobalHeapCollection)
+
+	for i := uint64(0); i < totalElements; i++ {
+		idStart := i * heapIDSize
+		if idStart+heapIDSize > uint64(len(rawData)) {
+			return nil, fmt.Errorf("heap ID %d extends beyond data", i)
+		}
+
+		heapRef, err := ParseGlobalHeapReference(rawData[idStart:idStart+heapIDSize], offsetSize)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse heap reference for element %d: %w", i, err)
+		}
+
+		// Null reference means empty/nil sequence.
+		if heapRef.HeapAddress == 0 && heapRef.ObjectIndex == 0 {
+			result[i] = []byte{}
+			continue
+		}
+
+		// Look up or read the global heap collection.
+		collection, ok := heapCache[heapRef.HeapAddress]
+		if !ok {
+			collection, err = ReadGlobalHeapCollection(r, heapRef.HeapAddress, offsetSize)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read global heap at 0x%X for element %d: %w",
+					heapRef.HeapAddress, i, err)
+			}
+			heapCache[heapRef.HeapAddress] = collection
+		}
+
+		obj, err := collection.GetObject(heapRef.ObjectIndex)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get heap object %d for element %d: %w",
+				heapRef.ObjectIndex, i, err)
+		}
+
+		// Copy the data to avoid holding references to the heap collection buffer.
+		data := make([]byte, len(obj.Data))
+		copy(data, obj.Data)
+		result[i] = data
+	}
+
+	return result, nil
+}

--- a/internal/core/messages_write.go
+++ b/internal/core/messages_write.go
@@ -360,37 +360,37 @@ func encodeDatatypeCompound(dt *DatatypeMessage) ([]byte, error) {
 
 // encodeDatatypeVLen encodes variable-length datatype (strings, ragged arrays).
 // VLen data is stored in global heap, dataset contains 16-byte heap IDs.
+//
+// C Reference: H5Odtype.c - H5O__dtype_encode_helper() lines 1352-1365, 1438-1442.
+// Header format (same as ALL datatypes):
+//
+//	Bytes 0-3: class (bits 0-3) | version (bits 4-7) | ClassBitField (bits 8-31)
+//	Bytes 4-7: Size (uint32 LE)
+//	Bytes 8+:  Base type message (nested datatype)
+//
+// ClassBitField for VLen (H5Odtype.c:1356-1359):
+//
+//	Bits 0-3:  VLen type (0=sequence, 1=string)
+//	Bits 4-7:  Padding type (for strings only)
+//	Bits 8-11: Character set (for strings: 0=ASCII, 1=UTF-8)
 func encodeDatatypeVLen(dt *DatatypeMessage) ([]byte, error) {
-	// VLen datatype format (HDF5 spec section 3.2.2.2):
-	// Header (8 bytes):
-	//   - Byte 0: Version (low 4 bits) | Class (high 4 bits)
-	//   - Bytes 1-3: Reserved (0)
-	//   - Bytes 4-7: Size (always 16 for vlen - heap ID size)
-	// Class-specific data (4 bytes):
-	//   - Byte 0: VLen type (0x00=sequence, 0x01=string)
-	//   - Byte 1: Padding (0x00)
-	//   - Bytes 2-3: Character set (for strings, 0x00=ASCII, 0x01=UTF-8)
-	// Base type message (variable length, nested datatype)
+	// Version 0 for VLen (most common).
+	version := dt.Version
 
-	// For version 0 VLen (most common)
-	version := uint8(0)
+	// Build message: 8-byte header + base type properties (no separate ClassBitField field).
+	buf := make([]byte, 8+len(dt.Properties))
 
-	// Build header (8 bytes)
-	buf := make([]byte, 8+4+len(dt.Properties))
+	// Pack class, version, and class bit field into bytes 0-3.
+	// This is the SAME pattern used by encodeDatatypeNumeric, encodeDatatypeString,
+	// encodeDatatypeCompound, and all other encode functions.
+	classAndVersion := uint32(dt.Class) | (uint32(version) << 4) | (dt.ClassBitField << 8)
+	binary.LittleEndian.PutUint32(buf[0:4], classAndVersion)
 
-	// Byte 0: version (low 4 bits) + class (high 4 bits)
-	buf[0] = version | (byte(dt.Class) << 4)
-
-	// Bytes 1-3: reserved (already zeros)
-
-	// Bytes 4-7: Size (16 bytes - heap ID size)
+	// Size (bytes 4-7).
 	binary.LittleEndian.PutUint32(buf[4:8], dt.Size)
 
-	// Bytes 8-11: Class-specific data (ClassBitField contains type/padding/charset)
-	binary.LittleEndian.PutUint32(buf[8:12], dt.ClassBitField)
-
-	// Bytes 12+: Base type message (nested datatype)
-	copy(buf[12:], dt.Properties)
+	// Base type message (bytes 8+).
+	copy(buf[8:], dt.Properties)
 
 	return buf, nil
 }

--- a/internal/core/objectheader_refcount_test.go
+++ b/internal/core/objectheader_refcount_test.go
@@ -170,22 +170,21 @@ func TestEncodeDatatypeVLen_String(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, data)
 
-	// Verify header: byte 0 is version (low 4) | class (high 4)
-	// Version 0, class 9 (VarLen) => 0x00 | (0x09 << 4) = 0x90
-	require.Equal(t, byte(0x90), data[0])
-
-	// Bytes 1-3 should be reserved (zeros)
-	require.Equal(t, byte(0), data[1])
-	require.Equal(t, byte(0), data[2])
-	require.Equal(t, byte(0), data[3])
+	// C Reference (H5Odtype.c:1438-1442):
+	// Bytes 0-3 = class (bits 0-3) | version (bits 4-7) | ClassBitField (bits 8-31)
+	// Class 9 (VarLen), version 0, ClassBitField 1 (string) =>
+	// uint32 LE = 0x09 | (0 << 4) | (1 << 8) = 0x00000109
+	require.Equal(t, byte(0x09), data[0]) // class=9, version=0
+	require.Equal(t, byte(0x01), data[1]) // ClassBitField bits 8-15: type=1 (string)
+	require.Equal(t, byte(0x00), data[2])
+	require.Equal(t, byte(0x00), data[3])
 
 	// Bytes 4-7: Size (16)
 	size := binary.LittleEndian.Uint32(data[4:8])
 	require.Equal(t, uint32(16), size)
 
-	// Bytes 8-11: ClassBitField (type=1 for string)
-	cbf := binary.LittleEndian.Uint32(data[8:12])
-	require.Equal(t, uint32(1), cbf)
+	// Total: 8 bytes header + 0 bytes properties = 8 bytes
+	require.Equal(t, 8, len(data))
 }
 
 // TestEncodeDatatypeVLen_Int tests encoding a variable-length integer sequence datatype.
@@ -211,22 +210,19 @@ func TestEncodeDatatypeVLen_Int(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, data)
 
-	// Total size: 8 (header) + 4 (ClassBitField) + 4 (base type props) = 16
-	require.Equal(t, 16, len(data))
+	// C Reference: bytes 0-3 = class|version|classBitField, bytes 4-7 = size, bytes 8+ = properties.
+	// Total size: 8 (header) + 4 (base type props) = 12.
+	require.Equal(t, 12, len(data))
 
-	// Verify header
-	require.Equal(t, byte(0x90), data[0]) // Version 0, class 9
+	// Verify header: class=9, version=0, classBitField=0 => byte 0 = 0x09.
+	require.Equal(t, byte(0x09), data[0])
 
-	// Verify size field
+	// Verify size field.
 	size := binary.LittleEndian.Uint32(data[4:8])
 	require.Equal(t, uint32(16), size)
 
-	// Verify ClassBitField (type=0 for sequence)
-	cbf := binary.LittleEndian.Uint32(data[8:12])
-	require.Equal(t, uint32(0), cbf)
-
-	// Verify base type properties are copied
-	require.Equal(t, baseTypeProps, data[12:16])
+	// Verify base type properties start at byte 8 (not 12).
+	require.Equal(t, baseTypeProps, data[8:12])
 }
 
 // TestEncodeDatatypeVLen_UTF8String tests encoding a vlen UTF-8 string.
@@ -246,9 +242,16 @@ func TestEncodeDatatypeVLen_UTF8String(t *testing.T) {
 	data, err := encodeDatatypeVLen(dt)
 	require.NoError(t, err)
 
-	// Verify ClassBitField encodes correctly
-	cbf := binary.LittleEndian.Uint32(data[8:12])
-	require.Equal(t, classBitField, cbf)
+	// C Reference: ClassBitField is packed into bytes 1-3 of the header uint32.
+	// class=9 | version=0<<4 | classBitField<<8 = 0x09 | (0x0101 << 8) = 0x00010109
+	// Bytes: 0x09, 0x01, 0x01, 0x00
+	require.Equal(t, byte(0x09), data[0])
+	require.Equal(t, byte(0x01), data[1]) // ClassBitField bits 0-7: type=1
+	require.Equal(t, byte(0x01), data[2]) // ClassBitField bits 8-15: charset=1 (UTF-8)
+	require.Equal(t, byte(0x00), data[3])
+
+	// Total: 8 bytes (no properties).
+	require.Equal(t, 8, len(data))
 }
 
 // --- Compound Datatype Encoding Tests ---
@@ -412,8 +415,9 @@ func TestEncodeDatatypeVLen_EmptyProperties(t *testing.T) {
 
 	data, err := encodeDatatypeVLen(dt)
 	require.NoError(t, err)
-	// Should be 12 bytes: 8 (header) + 4 (ClassBitField) + 0 (properties)
-	require.Equal(t, 12, len(data))
+	// C Reference: 8 bytes header + 0 properties = 8 bytes.
+	// ClassBitField is packed into header bytes 1-3, not a separate field.
+	require.Equal(t, 8, len(data))
 }
 
 // TestEncodeDatatypeVLen_WithBaseType tests vlen with base type properties.
@@ -433,9 +437,10 @@ func TestEncodeDatatypeVLen_WithBaseType(t *testing.T) {
 
 	data, err := encodeDatatypeVLen(dt)
 	require.NoError(t, err)
-	// Should be 24 bytes: 8 (header) + 4 (ClassBitField) + 12 (base type props)
-	require.Equal(t, 24, len(data))
+	// C Reference: 8 bytes header + 12 properties = 20 bytes.
+	// ClassBitField is packed into header bytes 1-3, not a separate field.
+	require.Equal(t, 20, len(data))
 
-	// Verify base type properties are at the end
-	require.Equal(t, baseTypeProps, data[12:24])
+	// Verify base type properties start at byte 8 (immediately after header).
+	require.Equal(t, baseTypeProps, data[8:20])
 }

--- a/vlen_roundtrip_test.go
+++ b/vlen_roundtrip_test.go
@@ -1,0 +1,212 @@
+package hdf5
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/scigolib/hdf5/internal/core"
+)
+
+// TestVLenUint8_RoundTrip writes VLenUint8 data, closes the file, reopens it,
+// reads back via ReadVLenBytes, and verifies the data matches exactly.
+func TestVLenUint8_RoundTrip(t *testing.T) {
+	filename := "test_vlen_uint8_roundtrip.h5"
+	defer os.Remove(filename)
+
+	expected := [][]byte{
+		{0x01, 0x02, 0x03},
+		{0xFF},
+		{0x00, 0xAB, 0xCD, 0xEF},
+	}
+
+	writeVLenUint8File(t, filename, "/bytes", expected)
+
+	f, err := Open(filename)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	dataset := findDataset(f, "/bytes")
+	if dataset == nil {
+		t.Fatal("Dataset '/bytes' not found after reopen")
+	}
+
+	got, err := dataset.ReadVLenBytes()
+	if err != nil {
+		t.Fatalf("ReadVLenBytes failed: %v", err)
+	}
+
+	assertVLenBytesEqual(t, expected, got)
+}
+
+// TestVLenUint8_Encode_ByteCheck writes a VLen dataset and verifies that the
+// datatype message header byte encodes class=9 correctly (0x09, not the
+// previous incorrect 0x90 from swapped nibbles).
+func TestVLenUint8_Encode_ByteCheck(t *testing.T) {
+	filename := "test_vlen_encode_check.h5"
+	defer os.Remove(filename)
+
+	writeVLenUint8File(t, filename, "/bytes", [][]byte{{0x01}, {0x02}})
+
+	firstByte := readVLenDatatypeFirstByte(t, filename)
+
+	// C Reference (H5Odtype.c:1439): byte 0 = (class & 0x0F) | (version << 4).
+	// For VLen class=9, version=0: byte 0 = 0x09.
+	class := firstByte & 0x0F
+	version := (firstByte >> 4) & 0x0F
+
+	if class != 9 {
+		t.Errorf("VLen datatype class: got %d (byte=0x%02X), want 9", class, firstByte)
+	}
+	if version != 0 {
+		t.Errorf("VLen datatype version: got %d, want 0", version)
+	}
+	if firstByte == 0x90 {
+		t.Error("BUG: first byte is 0x90 (class/version nibbles are SWAPPED)")
+	}
+}
+
+// TestVLenUint8_EmptySequences writes a mix of empty and non-empty byte sequences,
+// then reads them back and verifies correctness.
+func TestVLenUint8_EmptySequences(t *testing.T) {
+	filename := "test_vlen_uint8_empty_seq.h5"
+	defer os.Remove(filename)
+
+	expected := [][]byte{
+		{},           // empty
+		{0x42, 0x43}, // non-empty
+		{},           // empty
+		{0x01},       // single byte
+		{},           // empty
+	}
+
+	writeVLenUint8File(t, filename, "/mixed", expected)
+
+	f, err := Open(filename)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	dataset := findDataset(f, "/mixed")
+	if dataset == nil {
+		t.Fatal("Dataset '/mixed' not found")
+	}
+
+	got, err := dataset.ReadVLenBytes()
+	if err != nil {
+		t.Fatalf("ReadVLenBytes failed: %v", err)
+	}
+
+	assertVLenBytesEqual(t, expected, got)
+}
+
+// TestVLenUint8_LargeData writes 150 variable-length sequences and reads them back.
+func TestVLenUint8_LargeData(t *testing.T) {
+	filename := "test_vlen_uint8_large.h5"
+	defer os.Remove(filename)
+
+	const numElements = 150
+	expected := make([][]byte, numElements)
+	for i := range expected {
+		seq := make([]byte, i)
+		for j := range seq {
+			seq[j] = byte((i + j) & 0xFF)
+		}
+		expected[i] = seq
+	}
+
+	writeVLenUint8File(t, filename, "/large", expected)
+
+	f, err := Open(filename)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	dataset := findDataset(f, "/large")
+	if dataset == nil {
+		t.Fatal("Dataset '/large' not found")
+	}
+
+	got, err := dataset.ReadVLenBytes()
+	if err != nil {
+		t.Fatalf("ReadVLenBytes failed: %v", err)
+	}
+
+	assertVLenBytesEqual(t, expected, got)
+}
+
+// --- Test helpers ---
+
+// writeVLenUint8File creates an HDF5 file with a single VLenUint8 dataset.
+func writeVLenUint8File(t *testing.T, filename, path string, data [][]byte) {
+	t.Helper()
+	fw, err := CreateForWrite(filename, CreateTruncate)
+	if err != nil {
+		t.Fatalf("CreateForWrite failed: %v", err)
+	}
+
+	ds, err := fw.CreateDataset(path, VLenUint8, []uint64{uint64(len(data))})
+	if err != nil {
+		t.Fatalf("CreateDataset failed: %v", err)
+	}
+
+	if err := ds.Write(data); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	if err := fw.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+}
+
+// readVLenDatatypeFirstByte opens a file and returns the first byte of the
+// VLen dataset's datatype message.
+func readVLenDatatypeFirstByte(t *testing.T, filename string) byte {
+	t.Helper()
+	f, err := Open(filename)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	dataset := findDataset(f, "/bytes")
+	if dataset == nil {
+		t.Fatal("Dataset '/bytes' not found")
+	}
+
+	header, err := core.ReadObjectHeader(f.Reader(), dataset.Address(), f.Superblock())
+	if err != nil {
+		t.Fatalf("ReadObjectHeader failed: %v", err)
+	}
+
+	for _, msg := range header.Messages {
+		if msg.Type != core.MsgDatatype {
+			continue
+		}
+		if len(msg.Data) < 1 {
+			t.Fatal("Datatype message too short")
+		}
+		return msg.Data[0]
+	}
+
+	t.Fatal("Datatype message not found in object header")
+	return 0
+}
+
+// assertVLenBytesEqual checks that two [][]byte slices are equal element-by-element.
+func assertVLenBytesEqual(t *testing.T, expected, got [][]byte) {
+	t.Helper()
+	if len(got) != len(expected) {
+		t.Fatalf("length mismatch: got %d, want %d", len(got), len(expected))
+	}
+	for i := range expected {
+		if !bytes.Equal(got[i], expected[i]) {
+			t.Errorf("element %d mismatch: got %v (len=%d), want %v (len=%d)",
+				i, got[i], len(got[i]), expected[i], len(expected[i]))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `encodeDatatypeVlen`: class/version nibbles were swapped (`0x90` instead of `0x09`), ClassBitField at wrong byte offset. Per C reference `H5Odtype.c:1439`. All other encode functions were already correct.
- Add `ReadVLenBytes()` method on `Dataset` for reading VLen byte arrays back. Dereferences global heap IDs, supports compact/contiguous/chunked layouts.

## Test plan

- [x] `TestVLenUint8_RoundTrip` — write/close/reopen/read/verify
- [x] `TestVLenUint8_Encode_ByteCheck` — verify first byte is 0x09, not 0x90
- [x] `TestVLenUint8_EmptySequences` — mix of empty and non-empty
- [x] `TestVLenUint8_LargeData` — 150 variable-length sequences
- [x] Full test suite passes, lint clean (0 issues)

Closes #39
