### PR TITLE
fix: VLen h5dump interop — version, seq_len, GCOL free space (Issue #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v0.13.16] - 2026-03-30
+
+### Bug Fix
+
+#### VLen h5dump/h5ls full interoperability (Issue #39 follow-up)
+
+Fixed remaining VLen interoperability issues so h5dump can fully read VLen data, not just headers.
+
+**Bug #1: VLen datatype version 0 (must be >= 1)**
+
+Per C reference (`H5Odtype.c:151`), version must be >= `H5O_DTYPE_VERSION_1`. Our VLen encoder
+used version 0, causing immediate rejection by the C library's datatype decoder.
+
+**Bug #2: VLen Heap ID missing seq_len prefix**
+
+Per C reference (`H5Tvlen.c:876`), VLen disk format is `seq_len(4) + addr(8) + idx(4)`.
+Our encoder wrote `addr(8) + idx(4) + padding(4)`, causing the C library to parse our address
+bytes as the sequence length (garbage value).
+
+**Bug #3: VLen reader didn't skip seq_len**
+
+The dataset VLen reader passed all 16 bytes to `ParseGlobalHeapReference` without skipping
+the 4-byte seq_len prefix. The attribute reader (`attribute.go:367`) already did this correctly.
+
+**Bug #4: Global Heap free space object size off by 16**
+
+Per C reference (`H5HGcache.c:358`), for free space objects (idx=0), `need = obj[0].size`
+directly — the size field already includes the 16-byte object header. Our encoder subtracted
+16, leaving a gap of zero bytes that caused the C library's GCOL parser to enter an infinite
+loop (idx=0, size=0, pointer never advances).
+
+**Bug #5: Global Heap object refCount 1 instead of 0**
+
+Per C reference (`H5HG.c:324`), newly inserted objects have `nrefs = 0`. Changed for strict
+format conformance.
+
+**Validation**: h5dump displays VLen data correctly: `(1, 2, 3), (255), (0, 171)`.
+h5ls shows `variable length of native unsigned char`. Full round-trip verified.
+
+Reported by [@zhoujun24](https://github.com/zhoujun24).
+
+---
+
 ## [v0.13.15] - 2026-03-30
 
 ### Bug Fix

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Advantage**: We have official HDF5 C library as reference implementation!
 > **Approach**: Port proven algorithms, not invent from scratch - Senior Go Developer mindset
 
-**Last Updated**: 2026-03-30 | **Current Version**: v0.13.15 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.15 RELEASED! (2026-03-30) → v1.0.0 LTS (Q3 2026)
+**Last Updated**: 2026-03-30 | **Current Version**: v0.13.16 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.16 RELEASED! (2026-03-30) → v1.0.0 LTS (Q3 2026)
 
 ---
 
@@ -68,6 +68,8 @@ v0.13.13 (BUGFIX - SNOD/heap/chunk interop) ✅ RELEASED 2026-03-18
 v0.13.14 (HOTFIX - B-tree key semantics) ✅ RELEASED 2026-03-19
          ↓ (VLen encode fix + read support)
 v0.13.15 (BUGFIX - VLen encoding + ReadVLenBytes) ✅ RELEASED 2026-03-30
+         ↓ (VLen h5dump full interop)
+v0.13.16 (BUGFIX - VLen h5dump interop + GCOL fix) ✅ RELEASED 2026-03-30
          ↓ (maintenance continues)
 v0.13.x (maintenance phase) → Stable maintenance, bug fixes, minor enhancements
          ↓ (6-9 months production validation)

--- a/dataset_write.go
+++ b/dataset_write.go
@@ -395,7 +395,7 @@ type vlenTypeHandler struct {
 }
 
 func (h *vlenTypeHandler) GetInfo(_ *datasetConfig) (*datatypeInfo, error) {
-	// VLen datasets always store 16-byte heap IDs (8 address + 4 index + 4 padding)
+	// VLen datasets always store 16-byte heap IDs (4 seq_len + 8 address + 4 index)
 	// Don't set baseType here - VLen is the actual type for data writing
 	return &datatypeInfo{
 		class: core.DatatypeVarLen,
@@ -453,7 +453,7 @@ func (h *vlenTypeHandler) EncodeDatatypeMessage(_ *datatypeInfo) ([]byte, error)
 
 	msg := &core.DatatypeMessage{
 		Class:         core.DatatypeVarLen,
-		Version:       0,  // Version 0 for VLen
+		Version:       1,  // Version 1 minimum for VLen (C ref: H5Odtype.c:151 rejects version < 1)
 		Size:          16, // Heap ID size
 		ClassBitField: classBitField,
 		Properties:    baseTypeMsg, // Nested base type message
@@ -1361,6 +1361,9 @@ func (dw *DatasetWriter) writeVLen(data interface{}) error {
 			if err != nil {
 				return fmt.Errorf("write string %d to heap: %w", i, err)
 			}
+			// For VLen strings, seq_len = string length in bytes (characters).
+			// C ref: H5Tvlen.c:876 — UINT32ENCODE(vl, seq_len) where seq_len = nchars.
+			heapID.SeqLen = uint32(len(str)) //nolint:gosec // G115: string length fits in uint32
 			heapIDs[i] = heapID
 		}
 
@@ -1382,6 +1385,7 @@ func (dw *DatasetWriter) writeVLen(data interface{}) error {
 			if err != nil {
 				return fmt.Errorf("write int32 sequence %d to heap: %w", i, err)
 			}
+			heapID.SeqLen = uint32(len(seq)) //nolint:gosec // G115: sequence length fits in uint32
 			heapIDs[i] = heapID
 		}
 
@@ -1401,6 +1405,7 @@ func (dw *DatasetWriter) writeVLen(data interface{}) error {
 			if err != nil {
 				return fmt.Errorf("write int64 sequence %d to heap: %w", i, err)
 			}
+			heapID.SeqLen = uint32(len(seq)) //nolint:gosec // G115: sequence length fits in uint32
 			heapIDs[i] = heapID
 		}
 
@@ -1420,6 +1425,7 @@ func (dw *DatasetWriter) writeVLen(data interface{}) error {
 			if err != nil {
 				return fmt.Errorf("write uint32 sequence %d to heap: %w", i, err)
 			}
+			heapID.SeqLen = uint32(len(seq)) //nolint:gosec // G115: sequence length fits in uint32
 			heapIDs[i] = heapID
 		}
 
@@ -1439,6 +1445,7 @@ func (dw *DatasetWriter) writeVLen(data interface{}) error {
 			if err != nil {
 				return fmt.Errorf("write uint64 sequence %d to heap: %w", i, err)
 			}
+			heapID.SeqLen = uint32(len(seq)) //nolint:gosec // G115: sequence length fits in uint32
 			heapIDs[i] = heapID
 		}
 
@@ -1458,6 +1465,7 @@ func (dw *DatasetWriter) writeVLen(data interface{}) error {
 			if err != nil {
 				return fmt.Errorf("write float32 sequence %d to heap: %w", i, err)
 			}
+			heapID.SeqLen = uint32(len(seq)) //nolint:gosec // G115: sequence length fits in uint32
 			heapIDs[i] = heapID
 		}
 
@@ -1477,6 +1485,7 @@ func (dw *DatasetWriter) writeVLen(data interface{}) error {
 			if err != nil {
 				return fmt.Errorf("write float64 sequence %d to heap: %w", i, err)
 			}
+			heapID.SeqLen = uint32(len(seq)) //nolint:gosec // G115: sequence length fits in uint32
 			heapIDs[i] = heapID
 		}
 
@@ -1492,6 +1501,7 @@ func (dw *DatasetWriter) writeVLen(data interface{}) error {
 			if err != nil {
 				return fmt.Errorf("write uint8 sequence %d to heap: %w", i, err)
 			}
+			heapID.SeqLen = uint32(len(seq)) //nolint:gosec // G115: sequence length fits in uint32
 			heapIDs[i] = heapID
 		}
 
@@ -1499,7 +1509,7 @@ func (dw *DatasetWriter) writeVLen(data interface{}) error {
 		return fmt.Errorf("unsupported vlen data type: %T (expected []string or [][]numeric)", data)
 	}
 
-	// Encode heap IDs to bytes (16 bytes each: 8 addr + 4 index + 4 padding)
+	// Encode heap IDs to bytes (16 bytes each: 4 seq_len + 8 addr + 4 index)
 	heapIDData := make([]byte, len(heapIDs)*16)
 	for i, hid := range heapIDs {
 		encoded := hid.Encode() // Returns 16 bytes

--- a/global_heap_write.go
+++ b/global_heap_write.go
@@ -34,10 +34,17 @@ type globalHeapObjectBuilder struct {
 }
 
 // HeapID identifies a global heap object (collection address + object index).
-// Format: 8 bytes address + 4 bytes index (stored as 12 bytes in file, padded to 16).
+// On-disk VLen format (C ref: H5Tvlen.c:300, H5Tvlen.c:876):
+//
+//	seq_len (4 bytes) + heap_address (8 bytes) + object_index (4 bytes) = 16 bytes
+//
+// SeqLen is the number of elements in the variable-length sequence.
+// For VLen strings, SeqLen = string length in bytes (characters).
+// For VLen sequences (e.g., []int32), SeqLen = number of elements.
 type HeapID struct {
 	CollectionAddress uint64
 	ObjectIndex       uint16
+	SeqLen            uint32 // Number of elements in the VLen sequence
 }
 
 // newGlobalHeapWriter creates a new global heap writer.
@@ -210,8 +217,11 @@ func (ghw *globalHeapWriter) encodeHeapCollection() []byte {
 
 		offset += 4 // Reserved
 
-		// Free space size (remaining space minus this header)
-		freeSpaceSize := heap.freeSpace - 16
+		// Free space size: for idx=0 (free space marker), the C library's GCOL parser
+		// uses size directly as the advance amount (H5HGcache.c:358: need = obj[0].size).
+		// This differs from regular objects where need = H5HG_SIZEOF_OBJHDR + aligned_data_size.
+		// So free space size must include the 16-byte object header.
+		freeSpaceSize := heap.freeSpace
 		binary.LittleEndian.PutUint64(buf[offset:], freeSpaceSize)
 		offset += 8
 	}
@@ -221,13 +231,17 @@ func (ghw *globalHeapWriter) encodeHeapCollection() []byte {
 	return buf
 }
 
-// Encode encodes a heap ID to 16 bytes (HDF5 vlen reference format).
-// Format: 8 bytes address + 4 bytes index + 4 bytes padding.
+// Encode encodes a heap ID to 16 bytes (HDF5 vlen on-disk format).
+// Format (C ref: H5Tvlen.c:876, H5Tvlen.c:300):
+//
+//	Bytes 0-3:  seq_len (uint32 LE) — number of elements in sequence
+//	Bytes 4-11: heap_address (uint64 LE) — global heap collection address
+//	Bytes 12-15: object_index (uint32 LE) — index within the collection
 func (hid HeapID) Encode() []byte {
 	buf := make([]byte, 16)
-	binary.LittleEndian.PutUint64(buf[0:8], hid.CollectionAddress)
-	binary.LittleEndian.PutUint32(buf[8:12], uint32(hid.ObjectIndex))
-	// Bytes 12-15 are padding (already zeros)
+	binary.LittleEndian.PutUint32(buf[0:4], hid.SeqLen)
+	binary.LittleEndian.PutUint64(buf[4:12], hid.CollectionAddress)
+	binary.LittleEndian.PutUint32(buf[12:16], uint32(hid.ObjectIndex))
 	return buf
 }
 
@@ -240,7 +254,7 @@ func (ghc *globalHeapCollectionBuilder) hasSpace(objectSize uint64) bool {
 func (ghc *globalHeapCollectionBuilder) addObject(data []byte) uint16 {
 	obj := &globalHeapObjectBuilder{
 		index:    ghc.nextIndex,
-		refCount: 1, // New objects have refcount 1
+		refCount: 0, // C library writes 0 on insert (H5HG.c:324), increments via H5HG_link()
 		data:     data,
 	}
 

--- a/global_heap_write_test.go
+++ b/global_heap_write_test.go
@@ -2,6 +2,7 @@ package hdf5
 
 import (
 	"bytes"
+	"encoding/binary"
 	"os"
 	"testing"
 
@@ -316,34 +317,35 @@ func TestMultipleHeapCollections(t *testing.T) {
 	}
 }
 
-// TestHeapIDEncoding tests encoding heap IDs to 16-byte format.
+// TestHeapIDEncoding tests encoding heap IDs to 16-byte VLen format.
+// C ref: H5Tvlen.c:876 — format is seq_len(4) + addr(8) + idx(4) = 16 bytes.
 func TestHeapIDEncoding(t *testing.T) {
 	heapID := HeapID{
 		CollectionAddress: 0x123456789ABCDEF0,
 		ObjectIndex:       0x1234,
+		SeqLen:            42,
 	}
 
 	encoded := heapID.Encode()
 
-	// Should be 16 bytes
+	// Should be 16 bytes.
 	if len(encoded) != 16 {
 		t.Errorf("Expected 16 bytes, got %d", len(encoded))
 	}
 
-	// First 8 bytes: address (little-endian)
-	if encoded[0] != 0xF0 || encoded[7] != 0x12 {
-		t.Errorf("Address encoding incorrect: %x", encoded[0:8])
+	// First 4 bytes: seq_len (little-endian).
+	seqLen := binary.LittleEndian.Uint32(encoded[0:4])
+	if seqLen != 42 {
+		t.Errorf("SeqLen encoding incorrect: got %d, want 42", seqLen)
 	}
 
-	// Next 4 bytes: index (little-endian)
-	if encoded[8] != 0x34 || encoded[9] != 0x12 {
-		t.Errorf("Index encoding incorrect: %x", encoded[8:12])
+	// Next 8 bytes: address (little-endian).
+	if encoded[4] != 0xF0 || encoded[11] != 0x12 {
+		t.Errorf("Address encoding incorrect: %x", encoded[4:12])
 	}
 
-	// Last 4 bytes: padding (zeros)
-	for i := 12; i < 16; i++ {
-		if encoded[i] != 0 {
-			t.Errorf("Padding byte %d is not zero: %d", i, encoded[i])
-		}
+	// Last 4 bytes: index (little-endian).
+	if encoded[12] != 0x34 || encoded[13] != 0x12 {
+		t.Errorf("Index encoding incorrect: %x", encoded[12:16])
 	}
 }

--- a/internal/core/dataset_reader_vlen.go
+++ b/internal/core/dataset_reader_vlen.go
@@ -125,7 +125,12 @@ func ReadDatasetVLenBytes(r io.ReaderAt, header *ObjectHeader, sb *Superblock) (
 			return nil, fmt.Errorf("heap ID %d extends beyond data", i)
 		}
 
-		heapRef, err := ParseGlobalHeapReference(rawData[idStart:idStart+heapIDSize], offsetSize)
+		// VLen on-disk format (C ref: H5Tvlen.c:300, H5Tvlen.c:728):
+		//   Bytes 0-3:  seq_len (uint32 LE) — number of elements in sequence
+		//   Bytes 4-11: heap_address (offset_size bytes)
+		//   Bytes 12-15: object_index (4 bytes)
+		// Skip the first 4 bytes (seq_len) to get to the global heap reference.
+		heapRef, err := ParseGlobalHeapReference(rawData[idStart+4:idStart+heapIDSize], offsetSize)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse heap reference for element %d: %w", i, err)
 		}

--- a/internal/core/messages_write.go
+++ b/internal/core/messages_write.go
@@ -374,7 +374,7 @@ func encodeDatatypeCompound(dt *DatatypeMessage) ([]byte, error) {
 //	Bits 4-7:  Padding type (for strings only)
 //	Bits 8-11: Character set (for strings: 0=ASCII, 1=UTF-8)
 func encodeDatatypeVLen(dt *DatatypeMessage) ([]byte, error) {
-	// Version 0 for VLen (most common).
+	// Version must be >= 1 for VLen (C ref: H5Odtype.c:151 rejects version < 1).
 	version := dt.Version
 
 	// Build message: 8-byte header + base type properties (no separate ClassBitField field).

--- a/vlen_roundtrip_test.go
+++ b/vlen_roundtrip_test.go
@@ -53,15 +53,16 @@ func TestVLenUint8_Encode_ByteCheck(t *testing.T) {
 	firstByte := readVLenDatatypeFirstByte(t, filename)
 
 	// C Reference (H5Odtype.c:1439): byte 0 = (class & 0x0F) | (version << 4).
-	// For VLen class=9, version=0: byte 0 = 0x09.
+	// For VLen class=9, version=1: byte 0 = 0x19.
+	// C ref: H5Odtype.c:151 rejects version < H5O_DTYPE_VERSION_1 (= 1).
 	class := firstByte & 0x0F
 	version := (firstByte >> 4) & 0x0F
 
 	if class != 9 {
 		t.Errorf("VLen datatype class: got %d (byte=0x%02X), want 9", class, firstByte)
 	}
-	if version != 0 {
-		t.Errorf("VLen datatype version: got %d, want 0", version)
+	if version != 1 {
+		t.Errorf("VLen datatype version: got %d, want 1", version)
 	}
 	if firstByte == 0x90 {
 		t.Error("BUG: first byte is 0x90 (class/version nibbles are SWAPPED)")

--- a/vlen_write_test.go
+++ b/vlen_write_test.go
@@ -236,10 +236,19 @@ func TestVLenHeapIDStorage(t *testing.T) {
 		t.Fatalf("ReadAt failed: %v", err)
 	}
 
-	// Verify heap IDs are non-zero
-	heapAddr1 := binary.LittleEndian.Uint64(heapIDData[0:8])
-	heapIdx1 := binary.LittleEndian.Uint32(heapIDData[8:12])
+	// VLen on-disk format (C ref: H5Tvlen.c:876):
+	//   Bytes 0-3:   seq_len (uint32 LE)
+	//   Bytes 4-11:  heap_address (uint64 LE)
+	//   Bytes 12-15: object_index (uint32 LE)
 
+	// Verify first heap ID.
+	seqLen1 := binary.LittleEndian.Uint32(heapIDData[0:4])
+	heapAddr1 := binary.LittleEndian.Uint64(heapIDData[4:12])
+	heapIdx1 := binary.LittleEndian.Uint32(heapIDData[12:16])
+
+	if seqLen1 != uint32(len("first")) {
+		t.Errorf("First seq_len: got %d, want %d", seqLen1, len("first"))
+	}
 	if heapAddr1 == 0 {
 		t.Error("First heap address is zero")
 	}
@@ -247,9 +256,14 @@ func TestVLenHeapIDStorage(t *testing.T) {
 		t.Error("First heap index is zero")
 	}
 
-	heapAddr2 := binary.LittleEndian.Uint64(heapIDData[16:24])
-	heapIdx2 := binary.LittleEndian.Uint32(heapIDData[24:28])
+	// Verify second heap ID.
+	seqLen2 := binary.LittleEndian.Uint32(heapIDData[16:20])
+	heapAddr2 := binary.LittleEndian.Uint64(heapIDData[20:28])
+	heapIdx2 := binary.LittleEndian.Uint32(heapIDData[28:32])
 
+	if seqLen2 != uint32(len("second")) {
+		t.Errorf("Second seq_len: got %d, want %d", seqLen2, len("second"))
+	}
 	if heapAddr2 == 0 {
 		t.Error("Second heap address is zero")
 	}
@@ -257,13 +271,13 @@ func TestVLenHeapIDStorage(t *testing.T) {
 		t.Error("Second heap index is zero")
 	}
 
-	// Verify data is in global heap
+	// Verify data is in global heap.
 	ghc, err := core.ReadGlobalHeapCollection(f.Reader(), heapAddr1, 8)
 	if err != nil {
 		t.Fatalf("ReadGlobalHeapCollection failed: %v", err)
 	}
 
-	// Check first string
+	// Check first string.
 	obj1, err := ghc.GetObject(heapIdx1)
 	if err != nil {
 		t.Fatalf("GetObject(1) failed: %v", err)
@@ -272,7 +286,7 @@ func TestVLenHeapIDStorage(t *testing.T) {
 		t.Errorf("First string mismatch: expected 'first', got '%s'", string(obj1.Data))
 	}
 
-	// Check second string
+	// Check second string.
 	obj2, err := ghc.GetObject(heapIdx2)
 	if err != nil {
 		t.Fatalf("GetObject(2) failed: %v", err)
@@ -327,6 +341,8 @@ func TestVLenUint32(t *testing.T) {
 }
 
 // TestVLenUint8 tests uint8 variable-length byte arrays.
+//
+//nolint:gocognit // Test with subtests and raw byte verification is inherently complex.
 func TestVLenUint8(t *testing.T) {
 	filename := "test_vlen_uint8.h5"
 	fw, err := CreateForWrite(filename, CreateTruncate)
@@ -378,8 +394,15 @@ func TestVLenUint8(t *testing.T) {
 
 	for i, expected := range ragged {
 		t.Run(fmt.Sprintf("element_%d", i), func(t *testing.T) {
-			heapAddr := binary.LittleEndian.Uint64(heapIDData[i*16 : i*16+8])
-			heapIdx := binary.LittleEndian.Uint32(heapIDData[i*16+8 : i*16+12])
+			// VLen on-disk format: seq_len(4) + addr(8) + idx(4) = 16 bytes.
+			base := i * 16
+			seqLen := binary.LittleEndian.Uint32(heapIDData[base : base+4])
+			heapAddr := binary.LittleEndian.Uint64(heapIDData[base+4 : base+12])
+			heapIdx := binary.LittleEndian.Uint32(heapIDData[base+12 : base+16])
+
+			if seqLen != uint32(len(expected)) {
+				t.Errorf("seq_len mismatch: got %d, want %d", seqLen, len(expected))
+			}
 
 			ghc, err := core.ReadGlobalHeapCollection(f.Reader(), heapAddr, 8)
 			if err != nil {


### PR DESCRIPTION
## Summary

Fixes remaining VLen interoperability issues so h5dump/h5ls can fully read VLen data (not just headers).

- **VLen datatype version** 0→1 (C library rejects version < 1, per `H5Odtype.c:151`)
- **Heap ID format**: `seq_len(4)+addr(8)+idx(4)` instead of `addr(8)+idx(4)+pad(4)` (per `H5Tvlen.c:876`)
- **VLen reader**: skip 4-byte seq_len before parsing heap reference (matches `attribute.go:367`)
- **GCOL free space size**: include 16-byte object header (per `H5HGcache.c:358` — was causing h5dump infinite loop)
- **Object refCount**: 1→0 for strict conformance (per `H5HG.c:324`)

## Test plan

- [x] h5dump displays VLen data correctly: `(1, 2, 3), (255), (0, 171)`
- [x] h5ls shows `variable length of native unsigned char`
- [x] Round-trip tests pass (7 VLen tests)
- [x] Full test suite passes, lint clean (0 issues)

Closes #39
