### PR TITLE
fix: multi-level chunk B-tree — remove 64-chunk limit (Issue #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v0.13.18] - 2026-03-31
+
+### Bug Fix
+
+#### Multi-level chunk B-tree — remove 64-chunk limit (Issue #39 follow-up)
+
+v0.13.17 introduced a 64-chunk hard limit (single B-tree leaf node, K=32) that blocked users
+with large datasets. The C library handles this with multi-level B-trees, splitting full nodes
+and adding internal levels automatically.
+
+Implemented bottom-up B-tree construction: sorted entries are partitioned into leaf nodes (max 64
+each), internal nodes are built from leaf addresses with correct boundary keys and sibling links,
+recursing until a single root remains. Supports arbitrary depth (64 chunks at depth 0, 4096 at
+depth 1, 262K at depth 2).
+
+Reverted workaround chunk dimension changes in filter and iterator tests back to original values.
+
+**Validation**: h5dump reads files with 100, 200, and 1594 chunks correctly. All existing tests
+restored to original chunk sizes and passing.
+
+Reported by [@zhoujun24](https://github.com/zhoujun24).
+
+---
+
 ## [v0.13.17] - 2026-03-30
 
 ### Bug Fix

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Advantage**: We have official HDF5 C library as reference implementation!
 > **Approach**: Port proven algorithms, not invent from scratch - Senior Go Developer mindset
 
-**Last Updated**: 2026-03-30 | **Current Version**: v0.13.17 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.17 RELEASED! (2026-03-30) → v1.0.0 LTS (Q3 2026)
+**Last Updated**: 2026-03-31 | **Current Version**: v0.13.18 | **Strategy**: HDF5 2.0.0 compatible → security hardened → v1.0.0 LTS | **Milestone**: v0.13.18 RELEASED! (2026-03-31) → v1.0.0 LTS (Q3 2026)
 
 ---
 
@@ -72,6 +72,8 @@ v0.13.15 (BUGFIX - VLen encoding + ReadVLenBytes) ✅ RELEASED 2026-03-30
 v0.13.16 (BUGFIX - VLen h5dump interop + GCOL fix) ✅ RELEASED 2026-03-30
          ↓ (chunked B-tree interop)
 v0.13.17 (BUGFIX - chunked B-tree h5dump interop) ✅ RELEASED 2026-03-30
+         ↓ (multi-level B-tree)
+v0.13.18 (BUGFIX - multi-level chunk B-tree) ✅ RELEASED 2026-03-31
          ↓ (maintenance continues)
 v0.13.x (maintenance phase) → Stable maintenance, bug fixes, minor enhancements
          ↓ (6-9 months production validation)

--- a/dataset_chunk_iterator_test.go
+++ b/dataset_chunk_iterator_test.go
@@ -21,9 +21,8 @@ func createChunkedTestFile(t *testing.T) string {
 		t.Fatalf("CreateForWrite failed: %v", err)
 	}
 
-	// Create chunked dataset: 40x40 with 10x10 chunks = 16 chunks total.
-	// (Must fit in single B-tree leaf: max 2K=64 chunks with K=32.)
-	dw, err := fw.CreateDataset("/chunked_data", Float64, []uint64{40, 40},
+	// Create chunked dataset: 100x100 with 10x10 chunks = 100 chunks total.
+	dw, err := fw.CreateDataset("/chunked_data", Float64, []uint64{100, 100},
 		WithChunkDims([]uint64{10, 10}),
 	)
 	if err != nil {
@@ -31,7 +30,7 @@ func createChunkedTestFile(t *testing.T) string {
 	}
 
 	// Write data.
-	data := make([]float64, 40*40)
+	data := make([]float64, 100*100)
 	for i := range data {
 		data[i] = float64(i)
 	}

--- a/dataset_write_chunked_test.go
+++ b/dataset_write_chunked_test.go
@@ -357,13 +357,13 @@ func TestChunkedWrite_2D_MultiChunk(t *testing.T) {
 }
 
 // TestChunkedWrite_LargeDataset verifies a 1D dataset with many chunks.
-// 640 float64 elements, chunk size 10 = 64 chunks (max for single B-tree leaf, K=32).
+// 1000 float64 elements, chunk size 10 = 100 chunks (exercises multi-level B-tree).
 // Tests that all chunk coordinates are correctly encoded as byte offsets.
 func TestChunkedWrite_LargeDataset(t *testing.T) {
 	tmpDir := t.TempDir()
 	filename := filepath.Join(tmpDir, "large_chunked.h5")
 
-	n := uint64(640)
+	n := uint64(1000)
 	chunkSize := uint64(10)
 
 	// Write.
@@ -409,4 +409,56 @@ func TestChunkedWrite_LargeDataset(t *testing.T) {
 		}
 	})
 	require.True(t, found, "dataset /large not found")
+}
+
+// TestChunkedWrite_MultiLevel_RoundTrip writes a dataset with 100 chunks
+// (exceeds 64-entry single leaf limit), reads it back, and verifies all data.
+func TestChunkedWrite_MultiLevel_RoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	filename := filepath.Join(tmpDir, "multi_level_roundtrip.h5")
+
+	// 200 int32 elements with chunk size 2 = 100 chunks.
+	n := 200
+	expected := make([]int32, n)
+	for i := range expected {
+		expected[i] = int32(i * 3)
+	}
+
+	func() {
+		fw, err := CreateForWrite(filename, CreateTruncate)
+		require.NoError(t, err)
+		defer func() { _ = fw.Close() }()
+
+		ds, err := fw.CreateDataset("/data", Int32, []uint64{uint64(n)},
+			WithChunkDims([]uint64{2}))
+		require.NoError(t, err)
+
+		err = ds.Write(expected)
+		require.NoError(t, err)
+
+		// Verify 100 chunks created.
+		require.Equal(t, uint64(100), ds.chunkCoordinator.GetTotalChunks())
+
+		require.NoError(t, fw.Close())
+	}()
+
+	// Read back and verify all data.
+	f, err := Open(filename)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	var found bool
+	f.Walk(func(path string, obj Object) {
+		if ds, ok := obj.(*Dataset); ok && path == "/data" {
+			found = true
+			values, err := ds.Read()
+			require.NoError(t, err)
+			require.Len(t, values, n, "should have %d elements", n)
+
+			for i, v := range values {
+				require.InDelta(t, float64(expected[i]), v, 0.5, "element %d mismatch", i)
+			}
+		}
+	})
+	require.True(t, found, "dataset /data not found")
 }

--- a/dataset_write_filters_test.go
+++ b/dataset_write_filters_test.go
@@ -16,7 +16,7 @@ func TestChunkedDatasetWithGZIP(t *testing.T) {
 	require.NoError(t, err)
 
 	ds, err := file.CreateDataset("/data", Int32, []uint64{100, 100},
-		WithChunkDims([]uint64{25, 25}), // 16 chunks (must fit in single B-tree leaf, max 64)
+		WithChunkDims([]uint64{10, 10}),
 		WithGZIPCompression(6))
 	require.NoError(t, err)
 
@@ -138,7 +138,7 @@ func TestChunkedDatasetWithAllFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	ds, err := file.CreateDataset("/data", Float32, []uint64{200, 200},
-		WithChunkDims([]uint64{50, 50}), // 16 chunks (must fit in single B-tree leaf, max 64)
+		WithChunkDims([]uint64{20, 20}),
 		WithShuffle(),
 		WithGZIPCompression(6),
 		WithFletcher32())
@@ -474,7 +474,7 @@ func TestChunkedDatasetSmallChunks(t *testing.T) {
 
 	// Small chunks (10 elements each)
 	ds, err := file.CreateDataset("/data", Int32, []uint64{1000},
-		WithChunkDims([]uint64{200}), // 50 chunks (must fit in single B-tree leaf, max 64)
+		WithChunkDims([]uint64{10}),
 		WithGZIPCompression(6))
 	require.NoError(t, err)
 
@@ -541,7 +541,7 @@ func TestChunkedDataset2DWithFilters(t *testing.T) {
 	require.NoError(t, err)
 
 	ds, err := file.CreateDataset("/image", Uint8, []uint64{100, 100},
-		WithChunkDims([]uint64{25, 25}), // 16 chunks (must fit in single B-tree leaf, max 64)
+		WithChunkDims([]uint64{10, 10}),
 		WithShuffle(),
 		WithGZIPCompression(6),
 		WithFletcher32())

--- a/internal/structures/btree_chunk.go
+++ b/internal/structures/btree_chunk.go
@@ -6,6 +6,11 @@ import (
 	"sort"
 )
 
+// chunkBTreeK is the B-tree "K" parameter for chunked datasets.
+// Per C reference (H5Dbtree.c), HDF5_BTREE_CHUNK_IK_DEF = 32.
+// Each node holds at most 2K = 64 children.
+const chunkBTreeK = 32
+
 // ChunkBTreeNode represents B-tree v1 node for chunk indexing.
 // Format matches HDF5 specification for raw data chunk B-tree.
 //
@@ -179,77 +184,249 @@ func (w *ChunkBTreeWriter) WriteToFile(writer Writer, allocator Allocator) (uint
 		return 0, fmt.Errorf("no chunks to write (empty B-tree)")
 	}
 
-	// Per C reference, a single B-tree leaf node holds at most 2K children (K=32 → 64).
-	// Multi-level B-trees are not yet supported.
-	const chunkBTreeK = 32
-	if len(w.entries) > 2*chunkBTreeK {
-		return 0, fmt.Errorf("too many chunks (%d) for single B-tree leaf node (max %d); multi-level chunk B-tree not yet supported",
-			len(w.entries), 2*chunkBTreeK)
-	}
-
-	// 1. Sort entries by coordinate (row-major)
+	// 1. Sort entries by coordinate (row-major).
 	sort.Slice(w.entries, func(i, j int) bool {
 		return compareChunkCoords(w.entries[i].Coordinate, w.entries[j].Coordinate) < 0
 	})
 
-	// 2. Build node
-	node := &ChunkBTreeNode{
-		Signature:    [4]byte{'T', 'R', 'E', 'E'},
-		NodeType:     1,                      // Raw Data Chunk (NOT 0 like groups!)
-		NodeLevel:    0,                      // Leaf
-		EntriesUsed:  uint16(len(w.entries)), //nolint:gosec // G115: HDF5 limits B-tree entries to uint16
-		LeftSibling:  0xFFFFFFFFFFFFFFFF,     // Undefined (no siblings)
-		RightSibling: 0xFFFFFFFFFFFFFFFF,     // Undefined (no siblings)
+	maxPerNode := 2 * chunkBTreeK // 64
+
+	// 2. If entries fit in a single leaf, write a single node (fast path).
+	if len(w.entries) <= maxPerNode {
+		return w.writeSingleLeaf(writer, allocator)
 	}
 
-	// 3. Add keys and addresses
-	for _, entry := range w.entries {
+	// 3. Multi-level: build bottom-up.
+	return w.buildMultiLevelTree(writer, allocator)
+}
+
+// writeSingleLeaf writes all entries as a single leaf node (level 0).
+// This is the original behavior for datasets with at most 64 chunks.
+func (w *ChunkBTreeWriter) writeSingleLeaf(writer Writer, allocator Allocator) (uint64, error) {
+	onDiskDims := w.dimensionality + 1
+
+	node := w.buildLeafNode(w.entries, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)
+	buf := serializeChunkBTreeNode(node, onDiskDims, w.chunkDims, w.elementSize)
+
+	addr, err := allocator.Allocate(uint64(len(buf)))
+	if err != nil {
+		return 0, fmt.Errorf("failed to allocate space for B-tree: %w", err)
+	}
+
+	if err := writer.WriteAtAddress(buf, addr); err != nil {
+		return 0, fmt.Errorf("failed to write B-tree at address %d: %w", addr, err)
+	}
+
+	return addr, nil
+}
+
+// buildLeafNode creates a ChunkBTreeNode (level 0) from the given entries
+// with specified sibling addresses.
+func (w *ChunkBTreeWriter) buildLeafNode(entries []ChunkBTreeEntry, leftSibling, rightSibling uint64) *ChunkBTreeNode {
+	onDiskDims := w.dimensionality + 1
+
+	node := &ChunkBTreeNode{
+		Signature:    [4]byte{'T', 'R', 'E', 'E'},
+		NodeType:     1,
+		NodeLevel:    0,
+		EntriesUsed:  uint16(len(entries)), //nolint:gosec // G115: HDF5 limits B-tree entries to uint16
+		LeftSibling:  leftSibling,
+		RightSibling: rightSibling,
+	}
+
+	for _, entry := range entries {
 		node.Keys = append(node.Keys, ChunkKey{
 			Coords:     entry.Coordinate,
-			FilterMask: 0, // No filters in Phase 1
+			FilterMask: 0,
 			Nbytes:     entry.Nbytes,
 		})
 		node.ChildAddrs = append(node.ChildAddrs, entry.Address)
 	}
 
-	// 4. Add sentinel key (B-tree requirement: nchildren+1 keys).
-	// Per C reference (H5Dbtree.c:646), decode_key validates:
-	//   if (0 != (tmp_offset % layout->dim[u])) → error
-	// So sentinel coords MUST be divisible by chunk dims.
-	// Use the "next chunk position" after the last entry as sentinel.
-	onDiskDims := w.dimensionality + 1
+	// Sentinel key: next chunk position after last entry.
 	sentinelCoords := make([]uint64, onDiskDims)
-	if len(w.entries) > 0 {
-		lastEntry := w.entries[len(w.entries)-1]
+	if len(entries) > 0 {
+		lastEntry := entries[len(entries)-1]
 		for i := 0; i < w.dimensionality && i < len(lastEntry.Coordinate); i++ {
-			// Next chunk position = last coord + 1 (in scaled units).
-			// Will be multiplied by chunkDim during serialization.
 			sentinelCoords[i] = lastEntry.Coordinate[i] + 1
 		}
-		// Last dimension (element size) stays 0.
 	}
 	node.Keys = append(node.Keys, ChunkKey{
 		Coords:     sentinelCoords,
 		FilterMask: 0,
 	})
 
-	// 5. Serialize
-	// Per C reference (H5Dbtree.c:687-690), keys use ndims+1 dimensions
-	// and store byte offsets (scaled * chunkDim), not raw scaled indices.
-	buf := serializeChunkBTreeNode(node, onDiskDims, w.chunkDims, w.elementSize)
+	return node
+}
 
-	// 6. Allocate space
-	addr, err := allocator.Allocate(uint64(len(buf)))
-	if err != nil {
-		return 0, fmt.Errorf("failed to allocate space for B-tree: %w", err)
+// internalChild holds address and boundary keys for a child node in an internal B-tree node.
+type internalChild struct {
+	addr     uint64   // File address of child node.
+	firstKey ChunkKey // First key of the child (left boundary).
+	lastKey  ChunkKey // Sentinel key of the child (right boundary).
+}
+
+// buildMultiLevelTree constructs a multi-level B-tree v1 bottom-up.
+//
+// Algorithm:
+//  1. Partition sorted entries into groups of at most 2K (64) entries.
+//  2. For each group, build a leaf node (level 0) with sibling links.
+//  3. Allocate addresses for all leaf nodes, then serialize and write them.
+//  4. Build internal levels (level 1, 2, ...) from child node metadata until
+//     only one root node remains.
+//  5. Return root node address.
+func (w *ChunkBTreeWriter) buildMultiLevelTree(writer Writer, allocator Allocator) (uint64, error) {
+	maxPerNode := 2 * chunkBTreeK
+	onDiskDims := w.dimensionality + 1
+
+	// --- Level 0: leaf nodes ---
+
+	// Partition entries into groups.
+	var leafGroups [][]ChunkBTreeEntry
+	for i := 0; i < len(w.entries); i += maxPerNode {
+		end := i + maxPerNode
+		if end > len(w.entries) {
+			end = len(w.entries)
+		}
+		leafGroups = append(leafGroups, w.entries[i:end])
 	}
 
-	// 7. Write to file
-	if err := writer.WriteAtAddress(buf, addr); err != nil {
-		return 0, fmt.Errorf("failed to write B-tree at address %d: %w", addr, err)
+	// Compute node size (same for all nodes regardless of level).
+	// Per C reference (H5B.c:1670-1678):
+	//   sizeof_rkey = 4 + 4 + onDiskDims*8
+	//   sizeof_rnode = 24 + 2K*8 + (2K+1)*sizeof_rkey
+	keySize := 4 + 4 + onDiskDims*8
+	nodeSize := uint64(24 + 2*chunkBTreeK*8 + (2*chunkBTreeK+1)*keySize) //nolint:gosec // G115: constant expression, no overflow risk
+
+	// Pass 1: allocate addresses for all leaf nodes.
+	leafAddrs := make([]uint64, len(leafGroups))
+	for i := range leafGroups {
+		addr, err := allocator.Allocate(nodeSize)
+		if err != nil {
+			return 0, fmt.Errorf("failed to allocate leaf node %d: %w", i, err)
+		}
+		leafAddrs[i] = addr
 	}
 
-	return addr, nil
+	// Pass 2: build, serialize and write each leaf node with correct sibling links.
+	children := make([]internalChild, len(leafGroups))
+	for i, group := range leafGroups {
+		leftSib := uint64(0xFFFFFFFFFFFFFFFF)
+		rightSib := uint64(0xFFFFFFFFFFFFFFFF)
+		if i > 0 {
+			leftSib = leafAddrs[i-1]
+		}
+		if i < len(leafGroups)-1 {
+			rightSib = leafAddrs[i+1]
+		}
+
+		node := w.buildLeafNode(group, leftSib, rightSib)
+		buf := serializeChunkBTreeNode(node, onDiskDims, w.chunkDims, w.elementSize)
+
+		if err := writer.WriteAtAddress(buf, leafAddrs[i]); err != nil {
+			return 0, fmt.Errorf("failed to write leaf node %d at address %d: %w", i, leafAddrs[i], err)
+		}
+
+		// Record child metadata for parent internal node.
+		// firstKey = first key of this leaf, lastKey = sentinel (last key).
+		children[i] = internalChild{
+			addr:     leafAddrs[i],
+			firstKey: node.Keys[0],
+			lastKey:  node.Keys[len(node.Keys)-1],
+		}
+	}
+
+	// --- Internal levels (level 1, 2, ...) ---
+	level := uint8(1)
+	for len(children) > 1 {
+		children, _ = w.writeInternalLevel(writer, allocator, children, level, nodeSize)
+		if len(children) == 0 {
+			return 0, fmt.Errorf("failed to build internal level %d", level)
+		}
+		level++
+	}
+
+	// The single remaining child is the root.
+	return children[0].addr, nil
+}
+
+// writeInternalLevel builds and writes one level of internal B-tree nodes from
+// the given child list. Returns a new (smaller) child list for the next level.
+func (w *ChunkBTreeWriter) writeInternalLevel(
+	writer Writer,
+	allocator Allocator,
+	children []internalChild,
+	level uint8,
+	nodeSize uint64,
+) ([]internalChild, error) {
+	maxPerNode := 2 * chunkBTreeK
+	onDiskDims := w.dimensionality + 1
+
+	// Partition children into groups of at most 2K.
+	var groups [][]internalChild
+	for i := 0; i < len(children); i += maxPerNode {
+		end := i + maxPerNode
+		if end > len(children) {
+			end = len(children)
+		}
+		groups = append(groups, children[i:end])
+	}
+
+	// Pass 1: allocate addresses for all internal nodes at this level.
+	nodeAddrs := make([]uint64, len(groups))
+	for i := range groups {
+		addr, err := allocator.Allocate(nodeSize)
+		if err != nil {
+			return nil, fmt.Errorf("failed to allocate internal node level %d, node %d: %w", level, i, err)
+		}
+		nodeAddrs[i] = addr
+	}
+
+	// Pass 2: build, serialize, and write each internal node.
+	result := make([]internalChild, len(groups))
+	for i, group := range groups {
+		leftSib := uint64(0xFFFFFFFFFFFFFFFF)
+		rightSib := uint64(0xFFFFFFFFFFFFFFFF)
+		if i > 0 {
+			leftSib = nodeAddrs[i-1]
+		}
+		if i < len(groups)-1 {
+			rightSib = nodeAddrs[i+1]
+		}
+
+		node := &ChunkBTreeNode{
+			Signature:    [4]byte{'T', 'R', 'E', 'E'},
+			NodeType:     1,
+			NodeLevel:    level,
+			EntriesUsed:  uint16(len(group)), //nolint:gosec // G115: HDF5 limits B-tree entries to uint16
+			LeftSibling:  leftSib,
+			RightSibling: rightSib,
+		}
+
+		// Internal node keys: key[i] = first key of child[i] (boundary key).
+		// The sentinel (last key) = sentinel of the rightmost child.
+		for _, child := range group {
+			node.Keys = append(node.Keys, child.firstKey)
+			node.ChildAddrs = append(node.ChildAddrs, child.addr)
+		}
+		// Sentinel: use the sentinel (lastKey) from the last child in this group.
+		node.Keys = append(node.Keys, group[len(group)-1].lastKey)
+
+		buf := serializeChunkBTreeNode(node, onDiskDims, w.chunkDims, w.elementSize)
+
+		if err := writer.WriteAtAddress(buf, nodeAddrs[i]); err != nil {
+			return nil, fmt.Errorf("failed to write internal node level %d, node %d at address %d: %w",
+				level, i, nodeAddrs[i], err)
+		}
+
+		result[i] = internalChild{
+			addr:     nodeAddrs[i],
+			firstKey: node.Keys[0],
+			lastKey:  node.Keys[len(node.Keys)-1],
+		}
+	}
+
+	return result, nil
 }
 
 // serializeChunkBTreeNode serializes node to bytes.
@@ -282,7 +459,6 @@ func serializeChunkBTreeNode(node *ChunkBTreeNode, onDiskDims int, chunkDims []u
 	//   sizeof_rnode = H5B_SIZEOF_HDR(24) + 2K*sizeof_addr(8) + (2K+1)*sizeof_rkey
 	// Default K for chunk B-trees = 32 (HDF5_BTREE_CHUNK_IK_DEF).
 	// The buffer MUST be exactly sizeof_rnode bytes, zero-padded for unused slots.
-	const chunkBTreeK = 32
 	const offsetSize = 8 // sizeof_addr
 	keySize := 4 + 4 + onDiskDims*8
 	twoK := 2 * chunkBTreeK

--- a/internal/structures/btree_chunk_test.go
+++ b/internal/structures/btree_chunk_test.go
@@ -497,6 +497,217 @@ func TestChunkBTreeWriter_ErrorCases(t *testing.T) {
 	})
 }
 
+// TestChunkBTreeWriter_MultiLevel_65Chunks tests the minimum multi-level case:
+// 65 entries require 2 leaf nodes + 1 root internal node (level 1).
+func TestChunkBTreeWriter_MultiLevel_65Chunks(t *testing.T) {
+	chunkDims := []uint64{10}
+	elemSize := uint32(4) // int32
+	writer := NewChunkBTreeWriter(1, chunkDims, elemSize)
+
+	// Add 65 chunks (scaled indices 0..64). This exceeds the 64-entry single leaf limit.
+	for i := uint64(0); i < 65; i++ {
+		err := writer.AddChunk([]uint64{i}, 1000+i*80)
+		require.NoError(t, err)
+	}
+
+	mockWriter := newMockChunkWriter()
+	mockAllocator := newMockChunkAllocator(100000)
+
+	rootAddr, err := writer.WriteToFile(mockWriter, mockAllocator)
+	require.NoError(t, err)
+
+	// Root node should be an internal node (level 1).
+	rootData := mockWriter.ReadAt(rootAddr)
+	require.NotEmpty(t, rootData)
+	require.Equal(t, "TREE", string(rootData[0:4]))
+	require.Equal(t, uint8(1), rootData[4]) // Node type = chunk
+	require.Equal(t, uint8(1), rootData[5]) // Node level = 1 (internal)
+	rootEntries := binary.LittleEndian.Uint16(rootData[6:8])
+	require.Equal(t, uint16(2), rootEntries) // 2 children (2 leaf nodes)
+
+	// Parse root's children addresses.
+	onDiskDims := 2 // 1D + trailing
+	keySize := 4 + 4 + onDiskDims*8
+	pos := 24
+
+	// key[0], child[0], key[1], child[1], key[2] (sentinel)
+	pos += keySize // skip key[0]
+	child0Addr := binary.LittleEndian.Uint64(rootData[pos:])
+	pos += 8
+	pos += keySize // skip key[1]
+	child1Addr := binary.LittleEndian.Uint64(rootData[pos:])
+
+	// Both children should be leaf nodes (level 0).
+	child0Data := mockWriter.ReadAt(child0Addr)
+	require.NotEmpty(t, child0Data)
+	require.Equal(t, "TREE", string(child0Data[0:4]))
+	require.Equal(t, uint8(0), child0Data[5]) // level 0 = leaf
+	child0Entries := binary.LittleEndian.Uint16(child0Data[6:8])
+	require.Equal(t, uint16(64), child0Entries) // First leaf: 64 entries
+
+	child1Data := mockWriter.ReadAt(child1Addr)
+	require.NotEmpty(t, child1Data)
+	require.Equal(t, "TREE", string(child1Data[0:4]))
+	require.Equal(t, uint8(0), child1Data[5]) // level 0 = leaf
+	child1Entries := binary.LittleEndian.Uint16(child1Data[6:8])
+	require.Equal(t, uint16(1), child1Entries) // Second leaf: 1 entry
+
+	// Verify sibling links: child0.right = child1, child1.left = child0.
+	child0RightSib := binary.LittleEndian.Uint64(child0Data[16:24])
+	require.Equal(t, child1Addr, child0RightSib, "child0 right sibling should point to child1")
+	child1LeftSib := binary.LittleEndian.Uint64(child1Data[8:16])
+	require.Equal(t, child0Addr, child1LeftSib, "child1 left sibling should point to child0")
+
+	// Outer siblings should be UNDEF.
+	child0LeftSib := binary.LittleEndian.Uint64(child0Data[8:16])
+	require.Equal(t, uint64(0xFFFFFFFFFFFFFFFF), child0LeftSib)
+	child1RightSib := binary.LittleEndian.Uint64(child1Data[16:24])
+	require.Equal(t, uint64(0xFFFFFFFFFFFFFFFF), child1RightSib)
+
+	// Total entries across leaves = 64 + 1 = 65.
+	require.Equal(t, uint16(65), child0Entries+child1Entries)
+}
+
+// TestChunkBTreeWriter_MultiLevel_100Chunks tests multi-level with 100 entries
+// (2 leaf nodes: 64 + 36).
+func TestChunkBTreeWriter_MultiLevel_100Chunks(t *testing.T) {
+	chunkDims := []uint64{8}
+	elemSize := uint32(4)
+	writer := NewChunkBTreeWriter(1, chunkDims, elemSize)
+
+	for i := uint64(0); i < 100; i++ {
+		err := writer.AddChunk([]uint64{i}, 2000+i*40)
+		require.NoError(t, err)
+	}
+
+	mockWriter := newMockChunkWriter()
+	mockAllocator := newMockChunkAllocator(50000)
+
+	rootAddr, err := writer.WriteToFile(mockWriter, mockAllocator)
+	require.NoError(t, err)
+
+	// Root should be internal (level 1) with 2 children.
+	rootData := mockWriter.ReadAt(rootAddr)
+	require.Equal(t, uint8(1), rootData[5]) // level 1
+	rootEntries := binary.LittleEndian.Uint16(rootData[6:8])
+	require.Equal(t, uint16(2), rootEntries)
+
+	// Parse children and verify entry distribution.
+	onDiskDims := 2
+	keySize := 4 + 4 + onDiskDims*8
+	pos := 24 + keySize // skip key[0]
+	child0Addr := binary.LittleEndian.Uint64(rootData[pos:])
+	pos += 8 + keySize // skip child[0] + key[1]
+	child1Addr := binary.LittleEndian.Uint64(rootData[pos:])
+
+	child0Entries := binary.LittleEndian.Uint16(mockWriter.ReadAt(child0Addr)[6:8])
+	child1Entries := binary.LittleEndian.Uint16(mockWriter.ReadAt(child1Addr)[6:8])
+
+	require.Equal(t, uint16(100), child0Entries+child1Entries)
+	require.Equal(t, uint16(64), child0Entries)
+	require.Equal(t, uint16(36), child1Entries)
+}
+
+// TestChunkBTreeWriter_MultiLevel_200Chunks tests multi-level with 200 entries
+// (4 leaf nodes: 64 + 64 + 64 + 8).
+func TestChunkBTreeWriter_MultiLevel_200Chunks(t *testing.T) {
+	chunkDims := []uint64{5}
+	elemSize := uint32(8)
+	writer := NewChunkBTreeWriter(1, chunkDims, elemSize)
+
+	// Add 200 entries with known addresses.
+	for i := uint64(0); i < 200; i++ {
+		err := writer.AddChunkWithSize([]uint64{i}, 3000+i*40, 40)
+		require.NoError(t, err)
+	}
+
+	mockWriter := newMockChunkWriter()
+	mockAllocator := newMockChunkAllocator(80000)
+
+	rootAddr, err := writer.WriteToFile(mockWriter, mockAllocator)
+	require.NoError(t, err)
+
+	// Root should be level 1 (internal) with 4 children (ceil(200/64) = 4).
+	rootData := mockWriter.ReadAt(rootAddr)
+	require.Equal(t, "TREE", string(rootData[0:4]))
+	require.Equal(t, uint8(1), rootData[5]) // level 1
+	rootEntries := binary.LittleEndian.Uint16(rootData[6:8])
+	require.Equal(t, uint16(4), rootEntries)
+
+	// Collect all leaf entries from all children and verify every chunk address is present.
+	onDiskDims := 2 // 1D + trailing
+	keySize := 4 + 4 + onDiskDims*8
+	pos := 24
+
+	totalLeafEntries := uint16(0)
+	for i := 0; i < int(rootEntries); i++ {
+		pos += keySize // skip key[i]
+		childAddr := binary.LittleEndian.Uint64(rootData[pos:])
+		pos += 8
+
+		childData := mockWriter.ReadAt(childAddr)
+		require.Equal(t, uint8(0), childData[5], "child %d should be leaf (level 0)", i)
+		entries := binary.LittleEndian.Uint16(childData[6:8])
+		totalLeafEntries += entries
+	}
+
+	require.Equal(t, uint16(200), totalLeafEntries, "total entries across all leaves should be 200")
+
+	// Verify that leaf nodes have correct sibling chains.
+	// Re-read children for sibling verification.
+	pos = 24
+	childAddrs := make([]uint64, rootEntries)
+	for i := 0; i < int(rootEntries); i++ {
+		pos += keySize
+		childAddrs[i] = binary.LittleEndian.Uint64(rootData[pos:])
+		pos += 8
+	}
+
+	for i, addr := range childAddrs {
+		data := mockWriter.ReadAt(addr)
+		leftSib := binary.LittleEndian.Uint64(data[8:16])
+		rightSib := binary.LittleEndian.Uint64(data[16:24])
+
+		if i == 0 {
+			require.Equal(t, uint64(0xFFFFFFFFFFFFFFFF), leftSib, "first leaf left sibling should be UNDEF")
+		} else {
+			require.Equal(t, childAddrs[i-1], leftSib, "leaf %d left sibling mismatch", i)
+		}
+
+		if i == len(childAddrs)-1 {
+			require.Equal(t, uint64(0xFFFFFFFFFFFFFFFF), rightSib, "last leaf right sibling should be UNDEF")
+		} else {
+			require.Equal(t, childAddrs[i+1], rightSib, "leaf %d right sibling mismatch", i)
+		}
+	}
+}
+
+// TestChunkBTreeWriter_MultiLevel_2D tests multi-level tree with 2D coordinates.
+func TestChunkBTreeWriter_MultiLevel_2D(t *testing.T) {
+	chunkDims := []uint64{10, 10}
+	elemSize := uint32(4)
+	writer := NewChunkBTreeWriter(2, chunkDims, elemSize)
+
+	// Create a 10x10 grid of chunks = 100 total (exceeds 64 single-leaf limit).
+	for i := uint64(0); i < 10; i++ {
+		for j := uint64(0); j < 10; j++ {
+			err := writer.AddChunk([]uint64{i, j}, 5000+(i*10+j)*400)
+			require.NoError(t, err)
+		}
+	}
+
+	mockWriter := newMockChunkWriter()
+	mockAllocator := newMockChunkAllocator(200000)
+
+	rootAddr, err := writer.WriteToFile(mockWriter, mockAllocator)
+	require.NoError(t, err)
+
+	rootData := mockWriter.ReadAt(rootAddr)
+	require.Equal(t, uint8(1), rootData[5], "root should be internal (level 1)")
+	rootEntries := binary.LittleEndian.Uint16(rootData[6:8])
+	require.Equal(t, uint16(2), rootEntries, "100 entries should produce 2 leaf nodes")
+}
+
 // TestSerializeChunkBTreeNode tests serialization directly.
 // On disk, keys have onDiskDims dimensions (ndims+1) and store byte offsets.
 func TestSerializeChunkBTreeNode(t *testing.T) {


### PR DESCRIPTION
## Summary

Removes the 64-chunk hard limit introduced in v0.13.17 by implementing multi-level B-tree v1 bottom-up construction.

- Sorted entries partitioned into leaf nodes (max 64 each), internal nodes built from leaf addresses with correct boundary keys and sibling links
- Supports arbitrary depth: 64 chunks (depth 0), 4,096 (depth 1), 262K (depth 2)
- Reverted workaround chunk dims in filter/iterator tests back to original values
- Our reader already supported multi-level (`btree_v1.go` recursive `FindChunk`/`CollectAllChunks`)

## Test plan

- [x] h5dump: 200 elements / 100 chunks — all data correct
- [x] h5dump: 1594 chunks (user's robotics use case) — reads correctly
- [x] 4 new unit tests: 65, 100, 200 chunks + 2D multi-level
- [x] Integration test: 100-chunk round-trip write+read
- [x] All filter tests restored to original chunk sizes (100 chunks)
- [x] Full test suite passes, lint clean (0 issues)
