### PR TITLE
docs: update changelog and datatypes guide for PR #48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Enhancement
+
+#### Full fixed-point integer read support (PR #48)
+
+`Dataset.Read()` now correctly decodes all 8 native fixed-point types: int8, int16, int32,
+int64, uint8, uint16, uint32, uint64. Previously only int32 and int64 were supported — other
+widths returned "unsupported datatype", and uint32/uint64 values with the high bit set silently
+wrapped to negative through signed reinterpretation.
+
+The sign flag is now read from bit 3 of the HDF5 class bit field (per spec III.A.1.b), matching
+the C reference implementation (`H5Odtype.c`).
+
+Contributed by [@rhaist](https://github.com/rhaist).
+
+---
+
 ## [v0.13.19] - 2026-04-05
 
 ### Enhancement

--- a/docs/guides/DATATYPES.md
+++ b/docs/guides/DATATYPES.md
@@ -85,17 +85,41 @@ data, err := ds.Read()  // Returns []float64
 
 **Precision Note**: When converting int64 to float64, integers larger than 2^53 (9,007,199,254,740,992) may lose precision due to float64's mantissa limitations.
 
-#### Unsigned Integers
-
-**Status**: Partially supported (converted to signed)
+#### 8-bit Signed Integer
 
 **HDF5 Types**:
-- `H5T_STD_U32LE`, `H5T_STD_U32BE`
-- `H5T_STD_U64LE`, `H5T_STD_U64BE`
+- `H5T_STD_I8LE` (little-endian)
+- `H5T_STD_I8BE` (big-endian)
+- `H5T_NATIVE_INT8` (platform-native)
 
-**Go Conversion**: Read as native unsigned integers (uint8/uint16/uint32/uint64).
+**Go Type**: `int8`
 
-**Note**: All unsigned types (Uint8, Uint16, Uint32, Uint64) are fully supported for both reading and writing.
+**Range**: -128 to 127
+
+#### 16-bit Signed Integer
+
+**HDF5 Types**:
+- `H5T_STD_I16LE` (little-endian)
+- `H5T_STD_I16BE` (big-endian)
+- `H5T_NATIVE_INT16` (platform-native)
+
+**Go Type**: `int16`
+
+**Range**: -32,768 to 32,767
+
+#### Unsigned Integers
+
+**Status**: Fully supported (all widths)
+
+**HDF5 Types**:
+- `H5T_STD_U8LE/BE` (uint8)
+- `H5T_STD_U16LE/BE` (uint16)
+- `H5T_STD_U32LE/BE` (uint32)
+- `H5T_STD_U64LE/BE` (uint64)
+
+**Go Conversion**: Read as native unsigned integers, converted to float64 by `Dataset.Read()`.
+
+**Precision Note**: uint64 values above 2^53 (9,007,199,254,740,992) may lose precision when converted to float64.
 
 ### Floating-Point Types
 
@@ -145,10 +169,18 @@ data, err := ds.Read()  // Returns []float64 (native)
 
 | HDF5 Type | Size | Go Read Type | Conversion |
 |-----------|------|--------------|------------|
+| H5T_STD_I8LE/BE | 1 byte | float64 | int8 → float64 |
+| H5T_STD_I16LE/BE | 2 bytes | float64 | int16 → float64 |
 | H5T_STD_I32LE/BE | 4 bytes | float64 | int32 → float64 |
 | H5T_STD_I64LE/BE | 8 bytes | float64 | int64 → float64 |
+| H5T_STD_U8LE/BE | 1 byte | float64 | uint8 → float64 |
+| H5T_STD_U16LE/BE | 2 bytes | float64 | uint16 → float64 |
+| H5T_STD_U32LE/BE | 4 bytes | float64 | uint32 → float64 |
+| H5T_STD_U64LE/BE | 8 bytes | float64 | uint64 → float64 * |
 | H5T_IEEE_F32LE/BE | 4 bytes | float64 | float32 → float64 |
 | H5T_IEEE_F64LE/BE | 8 bytes | float64 | No conversion |
+
+\* uint64 values above 2^53 may lose precision in float64.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `[Unreleased]` section to CHANGELOG with PR #48 description and @rhaist attribution
- Add int8/int16 sections to DATATYPES.md (previously undocumented)
- Update unsigned integers status: "Partially supported" → "Fully supported (all widths)"
- Expand numeric type conversion table from 4 to 10 entries (all fixed-point types)

## Test plan

- [x] Documentation only — no code changes
- [x] `go build ./...` passes
- [x] `go vet ./...` clean