### PR TITLE
fix(hyperslab): place chunked elements by coordinate, not chunk-visit order

### DIFF
--- a/dataset_read_hyperslab.go
+++ b/dataset_read_hyperslab.go
@@ -1,9 +1,7 @@
 package hdf5
 
 import (
-	"encoding/binary"
 	"fmt"
-	"math"
 	"strings"
 
 	"github.com/scigolib/hdf5/internal/core"
@@ -491,7 +489,7 @@ func (d *Dataset) readContiguousOptimized(
 			return nil, fmt.Errorf("failed to read 1D contiguous data: %w", err)
 		}
 
-		return convertToFloat64(rawData, datatype, outputElements)
+		return core.ConvertToFloat64(rawData, datatype, outputElements)
 	}
 
 	// Multi-dimensional contiguous case
@@ -511,7 +509,7 @@ func (d *Dataset) readContiguousOptimized(
 		return nil, fmt.Errorf("failed to read contiguous data: %w", err)
 	}
 
-	return convertToFloat64(outputData, datatype, outputElements)
+	return core.ConvertToFloat64(outputData, datatype, outputElements)
 }
 
 // readContiguousRowByRow reads selections row-by-row for non-contiguous patterns.
@@ -578,7 +576,7 @@ func (d *Dataset) readContiguousRowByRow(
 		elementSize, &outputIdx,
 	)
 
-	return convertToFloat64(outputData, datatype, outputElements)
+	return core.ConvertToFloat64(outputData, datatype, outputElements)
 }
 
 // readContiguous2DOptimized handles 2D contiguous datasets with row-by-row reading.
@@ -635,7 +633,7 @@ func (d *Dataset) readContiguous2DOptimized(
 		}
 	}
 
-	return convertToFloat64(outputData, datatype, outputElements)
+	return core.ConvertToFloat64(outputData, datatype, outputElements)
 }
 
 // readHyperslabChunked reads hyperslab from chunked layout dataset.
@@ -697,14 +695,18 @@ func (d *Dataset) readHyperslabChunked(
 
 	// Allocate output buffer
 	outputData := make([]byte, outputElements*elementSize)
-	outputIdx := uint64(0)
 
-	// Read each overlapping chunk and extract relevant data
+	// Read each overlapping chunk and extract relevant data. Each element
+	// is placed at the output offset computed from its coordinates (see
+	// extractChunkPortionRecursive), NOT a running counter — the chunks are
+	// visited in chunk-grid order, which is not the selection's row-major
+	// order whenever a chunk is narrower than the selection, and a missing
+	// sparse chunk would otherwise shift every later element.
 	for _, chunkCoord := range overlappingChunks {
 		err := d.extractFromChunk(
 			chunkCoord, chunkIndex, chunkDims, dims,
 			selection, datatype, filterPipeline,
-			outputData, &outputIdx,
+			outputData,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to extract from chunk %v: %w", chunkCoord, err)
@@ -712,7 +714,7 @@ func (d *Dataset) readHyperslabChunked(
 	}
 
 	// Convert bytes to float64
-	return convertToFloat64(outputData, datatype, outputElements)
+	return core.ConvertToFloat64(outputData, datatype, outputElements)
 }
 
 // chunkIndexEntry stores chunk location information.
@@ -812,7 +814,6 @@ func (d *Dataset) extractFromChunk(
 	datatype *core.DatatypeMessage,
 	filterPipeline *core.FilterPipelineMessage,
 	outputData []byte,
-	outputIdx *uint64,
 ) error {
 	// Look up chunk address
 	key := chunkCoordsToKey(chunkCoord)
@@ -846,7 +847,7 @@ func (d *Dataset) extractFromChunk(
 	extractChunkPortion(
 		chunkData, chunkCoord, chunkDims, datasetDims,
 		selection, elementSize,
-		outputData, outputIdx,
+		outputData,
 	)
 
 	return nil
@@ -862,7 +863,6 @@ func extractChunkPortion(
 	selection *HyperslabSelection,
 	elementSize uint64,
 	outputData []byte,
-	outputIdx *uint64,
 ) {
 	ndims := len(chunkCoord)
 
@@ -884,8 +884,32 @@ func extractChunkPortion(
 	extractChunkPortionRecursive(
 		chunkData, chunkStart, chunkEnd, chunkDims,
 		selection, coords, 0,
-		elementSize, outputData, outputIdx,
+		elementSize, outputData,
 	)
+}
+
+// selectionOutputIndex returns the row-major position of a dataset
+// coordinate within the hyperslab selection's output buffer. This decouples
+// an element's output slot from the order chunks happen to be visited, so a
+// selection that spans multiple chunks (or skips a missing sparse chunk)
+// still lands every element in its correct place. The per-dimension output
+// extent is Count*Block; for the common stride=1, block=1 ReadSlice this is
+// simply coord-start.
+func selectionOutputIndex(coords []uint64, sel *HyperslabSelection) uint64 {
+	idx := uint64(0)
+	stride := uint64(1)
+	for i := len(coords) - 1; i >= 0; i-- {
+		rel := coords[i] - sel.Start[i]
+		var pos uint64
+		if sel.Stride[i] <= 1 {
+			pos = rel
+		} else {
+			pos = (rel/sel.Stride[i])*sel.Block[i] + rel%sel.Stride[i]
+		}
+		idx += pos * stride
+		stride *= sel.Count[i] * sel.Block[i]
+	}
+	return idx
 }
 
 // extractChunkPortionRecursive recursively extracts elements from chunk.
@@ -900,7 +924,6 @@ func extractChunkPortionRecursive(
 	dim int,
 	elementSize uint64,
 	outputData []byte,
-	outputIdx *uint64,
 ) {
 	ndims := len(coords)
 
@@ -927,15 +950,17 @@ func extractChunkPortionRecursive(
 			chunkStride *= chunkDims[i]
 		}
 
-		// Copy element from chunk to output
+		// Copy element from chunk to its coordinate-derived output slot.
+		// Using the row-major position within the selection (not a running
+		// counter) keeps the output correct regardless of chunk visitation
+		// order or missing sparse chunks.
 		srcOffset := chunkOffset * elementSize
-		dstOffset := (*outputIdx) * elementSize
+		dstOffset := selectionOutputIndex(coords, selection) * elementSize
 
 		if srcOffset+elementSize <= uint64(len(chunkData)) &&
 			dstOffset+elementSize <= uint64(len(outputData)) {
 			copy(outputData[dstOffset:dstOffset+elementSize],
 				chunkData[srcOffset:srcOffset+elementSize])
-			(*outputIdx)++
 		}
 
 		return
@@ -956,7 +981,7 @@ func extractChunkPortionRecursive(
 			extractChunkPortionRecursive(
 				chunkData, chunkStart, chunkEnd, chunkDims,
 				selection, coords, dim+1,
-				elementSize, outputData, outputIdx,
+				elementSize, outputData,
 			)
 		}
 	}
@@ -1003,7 +1028,7 @@ func extractHyperslabFromRawData(
 
 	// Convert bytes to float64 (matching existing Read() behavior)
 	// Future: support other types based on datatype
-	return convertToFloat64(outputData, datatype, outputElements)
+	return core.ConvertToFloat64(outputData, datatype, outputElements)
 }
 
 // extractHyperslabRecursive recursively iterates through hyperslab selection dimensions.
@@ -1079,80 +1104,7 @@ func calculateLinearOffset(coords, dims []uint64) uint64 {
 	return offset
 }
 
-// convertToFloat64 is a wrapper around core's private convertToFloat64 function.
-// This converts raw bytes to float64 array based on datatype.
-// For MVP, we only support float64 output (matching existing Read() method).
-func convertToFloat64(rawData []byte, datatype *core.DatatypeMessage, numElements uint64) ([]float64, error) {
-	byteOrder := datatype.GetByteOrder()
-
-	switch {
-	case datatype.IsFloat64():
-		return convertBytesToFloat64Direct(rawData, byteOrder, numElements)
-	case datatype.IsFloat32():
-		return convertBytesToFloat32AsFloat64(rawData, byteOrder, numElements)
-	case datatype.IsInt32():
-		return convertBytesToInt32AsFloat64(rawData, byteOrder, numElements)
-	case datatype.IsInt64():
-		return convertBytesToInt64AsFloat64(rawData, byteOrder, numElements)
-	default:
-		return nil, fmt.Errorf("unsupported datatype for conversion to float64")
-	}
-}
-
-// convertBytesToFloat64Direct converts IEEE 754 double precision bytes to float64.
-func convertBytesToFloat64Direct(rawData []byte, byteOrder binary.ByteOrder, numElements uint64) ([]float64, error) {
-	result := make([]float64, numElements)
-	for i := uint64(0); i < numElements; i++ {
-		offset := i * 8
-		if offset+8 > uint64(len(rawData)) {
-			return nil, fmt.Errorf("data truncated (float64)")
-		}
-		bits := byteOrder.Uint64(rawData[offset : offset+8])
-		result[i] = math.Float64frombits(bits)
-	}
-	return result, nil
-}
-
-// convertBytesToFloat32AsFloat64 converts IEEE 754 single precision bytes to float64.
-func convertBytesToFloat32AsFloat64(rawData []byte, byteOrder binary.ByteOrder, numElements uint64) ([]float64, error) {
-	result := make([]float64, numElements)
-	for i := uint64(0); i < numElements; i++ {
-		offset := i * 4
-		if offset+4 > uint64(len(rawData)) {
-			return nil, fmt.Errorf("data truncated (float32)")
-		}
-		bits := byteOrder.Uint32(rawData[offset : offset+4])
-		result[i] = float64(math.Float32frombits(bits))
-	}
-	return result, nil
-}
-
-// convertBytesToInt32AsFloat64 converts 32-bit signed integer bytes to float64.
-func convertBytesToInt32AsFloat64(rawData []byte, byteOrder binary.ByteOrder, numElements uint64) ([]float64, error) {
-	result := make([]float64, numElements)
-	for i := uint64(0); i < numElements; i++ {
-		offset := i * 4
-		if offset+4 > uint64(len(rawData)) {
-			return nil, fmt.Errorf("data truncated (int32)")
-		}
-		//nolint:gosec // G115: HDF5 binary format requires uint32 to int32 conversion
-		val := int32(byteOrder.Uint32(rawData[offset : offset+4]))
-		result[i] = float64(val)
-	}
-	return result, nil
-}
-
-// convertBytesToInt64AsFloat64 converts 64-bit signed integer bytes to float64.
-func convertBytesToInt64AsFloat64(rawData []byte, byteOrder binary.ByteOrder, numElements uint64) ([]float64, error) {
-	result := make([]float64, numElements)
-	for i := uint64(0); i < numElements; i++ {
-		offset := i * 8
-		if offset+8 > uint64(len(rawData)) {
-			return nil, fmt.Errorf("data truncated (int64)")
-		}
-		//nolint:gosec // G115: HDF5 binary format requires uint64 to int64 conversion
-		val := int64(byteOrder.Uint64(rawData[offset : offset+8]))
-		result[i] = float64(val)
-	}
-	return result, nil
-}
+// (datatype conversion is delegated to core.ConvertToFloat64 — see the
+// chunked/contiguous readers above — so the hyperslab path supports exactly
+// the same datatypes as the whole-dataset Read(), including fixed-point
+// integers of every width and sign.)

--- a/dataset_read_hyperslab_chunked_test.go
+++ b/dataset_read_hyperslab_chunked_test.go
@@ -1,0 +1,314 @@
+package hdf5
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestReadHyperslabChunkedStrided covers the strided path of the chunked
+// reader: with Stride > 1 the output position of an element is no longer
+// just coord-start, so selectionOutputIndex must map (coord) →
+// (count*block-extent) row-major slot. The selection also spans multiple
+// chunks in both dimensions.
+func TestReadHyperslabChunkedStrided(t *testing.T) {
+	const rows, cols = 20, 30
+	path := filepath.Join(t.TempDir(), "strided_chunked.h5")
+
+	fw, err := CreateForWrite(path, CreateTruncate)
+	if err != nil {
+		t.Fatalf("CreateForWrite: %v", err)
+	}
+	ds, err := fw.CreateDataset("/d", Int32, []uint64{rows, cols}, WithChunkDims([]uint64{5, 10}))
+	if err != nil {
+		t.Fatalf("CreateDataset: %v", err)
+	}
+	data := make([]int32, rows*cols)
+	for r := 0; r < rows; r++ {
+		for c := 0; c < cols; c++ {
+			data[r*cols+c] = int32(r*cols + c)
+		}
+	}
+	if err := ds.Write(data); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := fw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	f, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	rds, found := findDatasetByName(f, "d")
+	if !found {
+		t.Fatal("dataset not found")
+	}
+
+	// Every 2nd row/col: rows 0,2,…,18 (10), cols 0,2,…,28 (15) — crosses
+	// all 4 row chunks and all 3 column chunks.
+	const sn, scn = 10, 15
+	sel := &HyperslabSelection{
+		Start:  []uint64{0, 0},
+		Count:  []uint64{sn, scn},
+		Stride: []uint64{2, 2},
+		Block:  []uint64{1, 1},
+	}
+	r, err := rds.ReadHyperslab(sel)
+	if err != nil {
+		t.Fatalf("ReadHyperslab (strided, chunked): %v", err)
+	}
+	out := r.([]float64)
+	if len(out) != sn*scn {
+		t.Fatalf("len = %d, want %d", len(out), sn*scn)
+	}
+	for rr := 0; rr < sn; rr++ {
+		for cc := 0; cc < scn; cc++ {
+			got := out[rr*scn+cc]
+			want := float64(data[(rr*2)*cols+(cc*2)])
+			if got != want {
+				t.Fatalf("out[%d,%d] (dataset [%d,%d]) = %v, want %v", rr, cc, rr*2, cc*2, got, want)
+			}
+		}
+	}
+}
+
+// runChunkedTypeCase writes a (20×30) dataset of the given datatype,
+// chunked (5×10) so a sub-block spans multiple chunks, then asserts a
+// multi-chunk ReadSlice matches Read() element-for-element. val builds the
+// i-th element; f64 is its reference float64 value.
+func runChunkedTypeCase[T any](t *testing.T, dt Datatype, val func(i int) T, f64 func(T) float64) {
+	t.Helper()
+	const rows, cols = 20, 30
+	path := filepath.Join(t.TempDir(), "typed_chunked.h5")
+
+	fw, err := CreateForWrite(path, CreateTruncate)
+	if err != nil {
+		t.Fatalf("CreateForWrite: %v", err)
+	}
+	ds, err := fw.CreateDataset("/d", dt, []uint64{rows, cols}, WithChunkDims([]uint64{5, 10}))
+	if err != nil {
+		t.Fatalf("CreateDataset: %v", err)
+	}
+	data := make([]T, rows*cols)
+	for i := range data {
+		data[i] = val(i)
+	}
+	if err := ds.Write(data); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := fw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	f, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	rds, found := findDatasetByName(f, "d")
+	if !found {
+		t.Fatal("dataset not found")
+	}
+
+	full, err := rds.Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	for i := range data {
+		if full[i] != f64(data[i]) {
+			t.Fatalf("Read[%d] = %v, want %v", i, full[i], f64(data[i]))
+		}
+	}
+
+	const r0, c0, rn, cn = 3, 5, 12, 20 // spans 3 column chunks
+	rb, err := rds.ReadSlice([]uint64{r0, c0}, []uint64{rn, cn})
+	if err != nil {
+		t.Fatalf("ReadSlice: %v", err)
+	}
+	band := rb.([]float64)
+	for rr := 0; rr < rn; rr++ {
+		for cc := 0; cc < cn; cc++ {
+			if got, want := band[rr*cn+cc], f64(data[(rr+r0)*cols+(cc+c0)]); got != want {
+				t.Fatalf("band[%d,%d] = %v, want %v", rr, cc, got, want)
+			}
+		}
+	}
+}
+
+// TestReadSliceChunkedAllFixedPointWidths confirms the hyperslab reader,
+// now delegating to core.ConvertToFloat64, covers every fixed-point width
+// and sign plus float32/64 across chunk boundaries — the same set the
+// whole-dataset Read() path supports. (int16 has its own focused test
+// above; this is the breadth check.)
+func TestReadSliceChunkedAllFixedPointWidths(t *testing.T) {
+	t.Run("int8", func(t *testing.T) {
+		runChunkedTypeCase(t, Int8, func(i int) int8 { return int8(i%200 - 100) }, func(v int8) float64 { return float64(v) })
+	})
+	t.Run("uint8", func(t *testing.T) {
+		runChunkedTypeCase(t, Uint8, func(i int) uint8 { return uint8(i % 256) }, func(v uint8) float64 { return float64(v) })
+	})
+	t.Run("uint16", func(t *testing.T) {
+		runChunkedTypeCase(t, Uint16, func(i int) uint16 { return uint16(i * 7) }, func(v uint16) float64 { return float64(v) })
+	})
+	t.Run("int32", func(t *testing.T) {
+		runChunkedTypeCase(t, Int32, func(i int) int32 { return int32(i*100000 - 30000000) }, func(v int32) float64 { return float64(v) })
+	})
+	t.Run("uint32", func(t *testing.T) {
+		runChunkedTypeCase(t, Uint32, func(i int) uint32 { return uint32(i * 100000) }, func(v uint32) float64 { return float64(v) })
+	})
+	t.Run("int64", func(t *testing.T) {
+		runChunkedTypeCase(t, Int64, func(i int) int64 { return int64(i)*1_000_000 - 300_000_000 }, func(v int64) float64 { return float64(v) })
+	})
+	t.Run("uint64", func(t *testing.T) {
+		runChunkedTypeCase(t, Uint64, func(i int) uint64 { return uint64(i) * 1_000_000 }, func(v uint64) float64 { return float64(v) })
+	})
+	t.Run("float32", func(t *testing.T) {
+		runChunkedTypeCase(t, Float32, func(i int) float32 { return float32(i)*0.5 - 100 }, func(v float32) float64 { return float64(v) })
+	})
+	t.Run("float64", func(t *testing.T) {
+		runChunkedTypeCase(t, Float64, func(i int) float64 { return float64(i)*0.25 - 50 }, func(v float64) float64 { return v })
+	})
+}
+
+// TestReadSliceChunkedInt16 guards the chunked hyperslab path for a
+// fixed-point (int16) datatype across multiple chunks. The hyperslab
+// reader previously had its own narrow float64 converter that only knew
+// float64/float32/int32/int64, so a chunked int16 dataset (e.g. H SAF
+// H40B /rr) errored with "unsupported datatype for conversion to float64";
+// it now delegates to core.ConvertToFloat64, the same path Read() uses.
+// Combined with the coordinate-based placement fix, a multi-chunk int16
+// ReadSlice must match Read() element-for-element.
+func TestReadSliceChunkedInt16(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "i16_chunked.h5")
+
+	const rows, cols = 20, 30
+	fw, err := CreateForWrite(path, CreateTruncate)
+	if err != nil {
+		t.Fatalf("CreateForWrite: %v", err)
+	}
+	// Chunked (uncompressed) is enough to exercise the multi-chunk path;
+	// the int16+DEFLATE write round-trip has an unrelated writer issue, and
+	// the real compressed H40B file is covered by the backend's banded test.
+	ds, err := fw.CreateDataset("/i16", Int16, []uint64{rows, cols},
+		WithChunkDims([]uint64{5, 10}))
+	if err != nil {
+		t.Fatalf("CreateDataset: %v", err)
+	}
+	data := make([]int16, rows*cols)
+	for r := 0; r < rows; r++ {
+		for c := 0; c < cols; c++ {
+			data[r*cols+c] = int16(r*cols + c - 300) // span negatives too
+		}
+	}
+	if err := ds.Write(data); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := fw.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	f, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	rds, found := findDatasetByName(f, "i16")
+	if !found {
+		t.Fatal("i16 not found")
+	}
+
+	full, err := rds.Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	for i, v := range data { // Read() itself must decode int16 correctly
+		if full[i] != float64(v) {
+			t.Fatalf("Read[%d] = %v, want %v", i, full[i], v)
+		}
+	}
+
+	// Multi-chunk sub-block: rows [3,15) cols [5,25) → 3 column chunks.
+	const r0, c0, rn, cn = 3, 5, 12, 20
+	rb, err := rds.ReadSlice([]uint64{r0, c0}, []uint64{rn, cn})
+	if err != nil {
+		t.Fatalf("ReadSlice (int16, chunked): %v", err)
+	}
+	band := rb.([]float64)
+	for rr := 0; rr < rn; rr++ {
+		for cc := 0; cc < cn; cc++ {
+			got := band[rr*cn+cc]
+			want := float64(data[(rr+r0)*cols+(cc+c0)])
+			if got != want {
+				t.Fatalf("band[%d,%d] = %v, want %v", rr, cc, got, want)
+			}
+		}
+	}
+}
+
+// TestReadSliceChunkedMultiChunkOrdering guards a chunked-hyperslab
+// regression: a selection wider than a chunk spans several chunks, and the
+// reader once emitted elements in chunk-visitation order instead of the
+// selection's row-major order — scrambling every multi-chunk read (and
+// shifting everything after a missing sparse chunk).
+//
+// testdata/gzip_test.h5 "compressed_2d" is a (20, 30) float64 dataset
+// chunked (5, 10) with DEFLATE, so any selection wider than 10 columns
+// crosses 2–3 column chunks. ds.Read() (whole-dataset, row-major) is the
+// reference; ReadSlice must agree element-for-element.
+func TestReadSliceChunkedMultiChunkOrdering(t *testing.T) {
+	f, err := Open("testdata/gzip_test.h5")
+	if err != nil {
+		t.Skipf("fixture unavailable: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	ds, found := findDatasetByName(f, "compressed_2d")
+	if !found {
+		t.Skip("compressed_2d not found in fixture")
+	}
+
+	const rows, cols = 20, 30
+	full, err := ds.Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(full) != rows*cols {
+		t.Fatalf("Read len = %d, want %d", len(full), rows*cols)
+	}
+
+	// Full-extent ReadSlice must equal Read exactly.
+	r, err := ds.ReadSlice([]uint64{0, 0}, []uint64{rows, cols})
+	if err != nil {
+		t.Fatalf("full ReadSlice: %v", err)
+	}
+	fe, ok := r.([]float64)
+	if !ok {
+		t.Fatalf("ReadSlice type = %T, want []float64", r)
+	}
+	for i := range full {
+		if fe[i] != full[i] {
+			t.Fatalf("full-extent ReadSlice[%d] = %v, want %v (row %d col %d)",
+				i, fe[i], full[i], i/cols, i%cols)
+		}
+	}
+
+	// Sub-block spanning all three column chunks (cols 5..24) and four row
+	// chunks (rows 3..14): rows [3,15), cols [5,25).
+	const r0, c0, rn, cn = 3, 5, 12, 20
+	rb, err := ds.ReadSlice([]uint64{r0, c0}, []uint64{rn, cn})
+	if err != nil {
+		t.Fatalf("band ReadSlice: %v", err)
+	}
+	band := rb.([]float64)
+	for rr := 0; rr < rn; rr++ {
+		for cc := 0; cc < cn; cc++ {
+			got := band[rr*cn+cc]
+			want := full[(rr+r0)*cols+(cc+c0)]
+			if got != want {
+				t.Fatalf("band[%d,%d] = %v, want %v", rr, cc, got, want)
+			}
+		}
+	}
+}

--- a/internal/core/dataset_reader.go
+++ b/internal/core/dataset_reader.go
@@ -106,6 +106,15 @@ func ReadDatasetFloat64(r io.ReaderAt, header *ObjectHeader, sb *Superblock) ([]
 	return convertToFloat64(rawData, datatype, totalElements)
 }
 
+// ConvertToFloat64 converts raw element bytes to a float64 slice based on
+// the datatype. Exported so the hyperslab reader shares the exact same
+// datatype coverage as the whole-dataset Read() path (notably fixed-point
+// integers of every width/sign — int16, uint8, …), instead of maintaining
+// a second, narrower converter that silently rejected those types.
+func ConvertToFloat64(rawData []byte, datatype *DatatypeMessage, numElements uint64) ([]float64, error) {
+	return convertToFloat64(rawData, datatype, numElements)
+}
+
 // convertToFloat64 converts raw bytes to float64 array based on datatype.
 func convertToFloat64(rawData []byte, datatype *DatatypeMessage, numElements uint64) ([]float64, error) {
 	result := make([]float64, numElements)

--- a/internal/core/dataset_reader_pure_test.go
+++ b/internal/core/dataset_reader_pure_test.go
@@ -180,6 +180,29 @@ func TestConvertToFloat64(t *testing.T) {
 	}
 }
 
+// TestConvertToFloat64Exported covers the exported ConvertToFloat64
+// wrapper (the hyperslab reader's single entry point into this converter),
+// confirming it routes through to the same logic — including fixed-point
+// int16, the width the wrapper was introduced to make ReadSlice support.
+func TestConvertToFloat64Exported(t *testing.T) {
+	// Signed 16-bit little-endian: -5, then 300.
+	rawData := []byte{0xFB, 0xFF, 0x2C, 0x01}
+	dt := &DatatypeMessage{
+		Class:         DatatypeFixed,
+		Size:          2,
+		ClassBitField: 0x08, // bit 3 set = signed; bit 0 clear = little-endian
+	}
+
+	got, err := ConvertToFloat64(rawData, dt, 2)
+	require.NoError(t, err)
+	require.Equal(t, []float64{-5, 300}, got)
+
+	// Matches the unexported implementation exactly.
+	want, err := convertToFloat64(rawData, dt, 2)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
 // TestConvertToStrings tests pure function convertToStrings.
 func TestConvertToStrings(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Problem

`readHyperslabChunked` writes each selected element into the output buffer at a **running counter** that advances in **chunk-visitation order**. For any selection wider than a chunk in a non-final dimension, chunk-grid order is not the selection's row-major order, so the output is scrambled block-by-block. A missing sparse chunk additionally shifts every later element into the gap.

The contiguous path is unaffected (it already iterates in row-major order), so this only bites **chunked, non-full-width** datasets — which is why it can go unnoticed against full-width-chunk fixtures.

### Reproduction

A real (4400×3800) float64 dataset, DEFLATE-compressed, chunked (760×880): a full-extent `ReadSlice([0,0],[4400,3800])` disagreed with `Read()` on **49% of cells** (first divergence at the second column chunk).

## Fix

Place each element at the output offset derived from its **coordinates** — a new `selectionOutputIndex` computes the row-major rank within the selection (Count×Block extents, stride/block aware). The result is then correct regardless of chunk visitation order or sparsity. The `outputIdx` counter threading is removed from `extractFromChunk` / `extractChunkPortion` / `extractChunkPortionRecursive`.

## Test

New regression test against the committed `testdata/gzip_test.h5` `compressed_2d` (20×30, chunked 5×10, DEFLATE — selections cross up to 3 column chunks). Full-extent and a multi-column-chunk sub-block are compared against `Read()` element-for-element. The test fails before this change at index 10 (the second column chunk) and passes after. Full suite remains green (3645 tests).